### PR TITLE
Adding jsonignore to dlr structure for status

### DIFF
--- a/Nexmo.Api.Test.Unit/MessagingTests.cs
+++ b/Nexmo.Api.Test.Unit/MessagingTests.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using Nexmo.Api.Messaging;
 using System;
 using System.Collections.Generic;
@@ -212,6 +213,43 @@ namespace Nexmo.Api.Test.Unit
                   ""client-ref"": ""steve""
                 }";
             var dlr = JsonConvert.DeserializeObject<Messaging.DeliveryReceipt>(jsonFromNDP);
+            Assert.Equal("447700900000", dlr.Msisdn);
+            Assert.Equal("AcmeInc", dlr.To);
+            Assert.Equal("12345", dlr.NetworkCode);
+            Assert.Equal("0A0000001234567B", dlr.MessageId);
+            Assert.Equal("0.03330000", dlr.Price);
+            Assert.Equal(Messaging.DlrStatus.delivered, dlr.Status);
+            Assert.Equal("2001011400", dlr.Scts);
+            Assert.Equal("0", dlr.ErrorCode);
+            Assert.Equal("abcd1234", dlr.ApiKey);
+            Assert.Equal("2020-01-01T12:00:00.000+00:00", dlr.MessageTimestamp);
+            Assert.True(1582650446 == dlr.Timestamp);
+            Assert.Equal("ec11dd3e-1e7f-4db5-9467-82b02cd223b9", dlr.Nonce);
+            Assert.Equal("1A20E4E2069B609FDA6CECA9DE18D5CAFE99720DDB628BD6BE8B19942A336E1C", dlr.Sig);
+            Assert.Equal("steve", dlr.ClientRef);
+        }
+
+        [Fact]
+        public void TestDlrStructCamelCaseIgnore()
+        {
+            var jsonFromNDP = @"{
+                  ""msisdn"": ""447700900000"",
+                  ""to"": ""AcmeInc"",
+                  ""network-code"": ""12345"",
+                  ""messageId"": ""0A0000001234567B"",
+                  ""price"": ""0.03330000"",
+                  ""status"": ""delivered"",
+                  ""scts"": ""2001011400"",
+                  ""err-code"": ""0"",
+                  ""api-key"": ""abcd1234"",
+                  ""message-timestamp"": ""2020-01-01T12:00:00.000+00:00"",
+                  ""timestamp"": 1582650446,
+                  ""nonce"": ""ec11dd3e-1e7f-4db5-9467-82b02cd223b9"",
+                  ""sig"": ""1A20E4E2069B609FDA6CECA9DE18D5CAFE99720DDB628BD6BE8B19942A336E1C"",
+                  ""client-ref"": ""steve""
+                }";
+            var settings = new JsonSerializerSettings { ContractResolver = new CamelCasePropertyNamesContractResolver() };
+            var dlr = JsonConvert.DeserializeObject<Messaging.DeliveryReceipt>(jsonFromNDP, settings);
             Assert.Equal("447700900000", dlr.Msisdn);
             Assert.Equal("AcmeInc", dlr.To);
             Assert.Equal("12345", dlr.NetworkCode);

--- a/Nexmo.Api/Messaging/DeliveryReceipt.cs
+++ b/Nexmo.Api/Messaging/DeliveryReceipt.cs
@@ -45,6 +45,7 @@ namespace Nexmo.Api.Messaging
         /// <summary>
         /// A code that explains where the message is in the delivery process.
         /// </summary>
+        [JsonIgnore]
         public DlrStatus Status
         {
             get

--- a/Nexmo.Api/Nexmo.Api.csproj
+++ b/Nexmo.Api/Nexmo.Api.csproj
@@ -15,7 +15,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>5.2.0</Version>
+    <Version>5.2.1</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseExpression></PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Nexmo/nexmo-dotnet</PackageProjectUrl>

--- a/Nexmo.Api/Nexmo.Api.nuspec
+++ b/Nexmo.Api/Nexmo.Api.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Nexmo.Csharp.Client</id>
-    <version>5.2.0</version>
+    <version>5.2.1</version>
     <title>Nexmo API Client</title>
     <authors>Nexmo</authors>
     <owners>Nexmo</owners>
@@ -12,7 +12,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Official C#/.NET wrapper for the Nexmo API</description>
     <releaseNotes>
-https://github.com/Nexmo/nexmo-dotnet/releases/tag/v5.2.0
+https://github.com/Nexmo/nexmo-dotnet/releases/tag/v5.2.1
     </releaseNotes>
     <copyright>© Nexmo 2020</copyright>
     <tags>SMS voice telephony phone nexmo vonage</tags>

--- a/Nexmo.Api/Properties/AssemblyInfo.cs
+++ b/Nexmo.Api/Properties/AssemblyInfo.cs
@@ -34,5 +34,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.2.0.0")]
-[assembly: AssemblyFileVersion("5.2.0.0")]
+[assembly: AssemblyVersion("5.2.1.0")]
+[assembly: AssemblyFileVersion("5.2.1.0")]


### PR DESCRIPTION
We're missing a `JsonIgnore` attribute above the `Status` property of `DeliveryReceipt`, in a normal case this isn't a problem but if someone has non-standard serialization turned on the `Status` property could convert to `status` if not properly ignored, causing an error as there is already a JsonProperty for `status`. This is the cause of #212 