### PR TITLE
fixing unit test

### DIFF
--- a/Vonage.Test.Unit/MessagingTests.cs
+++ b/Vonage.Test.Unit/MessagingTests.cs
@@ -132,7 +132,7 @@ namespace Vonage.Test.Unit
                   ]
                 }";
             var expectedUri = $"{RestUrl}/sms/json?";
-            var expectedRequestContent = $"from=AcmeInc&to=447700900000&text={HttpUtility.UrlEncode("Hello World!")}&api_key={ApiKey}&api_secret={ApiSecret}&";
+            var expectedRequestContent = $"from=AcmeInc&to=447700900000&text={HttpUtility.UrlEncode("Hello World!")}&type=text&api_key={ApiKey}&api_secret={ApiSecret}&";
             Setup(expectedUri, expectedResponse, expectedRequestContent);
             var client = new VonageClient(Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret));
             var response = client.SmsClient.SendAnSms("AcmeInc", "447700900000", "Hello World!");


### PR DESCRIPTION
Fixing a unit test that is breaking the build currently - when the new simplified version of `SendAnSms` is called, it adds the type to the request URL - which isn't accounted for in the unit test. As this is only a change to a test it will not warrant a new release.