### PR TITLE
Syncronous methods blazor

### DIFF
--- a/Vonage.Test.Unit/AccountTest.cs
+++ b/Vonage.Test.Unit/AccountTest.cs
@@ -35,7 +35,34 @@ namespace Vonage.Test.Unit
             Assert.Equal(3.14159m, balance.Value);
             Assert.False(balance.AutoReload);
         }
-        
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async void GetAccountBalanceAsync(bool passCreds)
+        {
+            //ARRANGE
+            var expectedUri = $"{RestUrl}/account/get-balance?api_key={ApiKey}&api_secret={ApiSecret}&";
+            var expectedResponseContent = @"{""value"": 3.14159, ""autoReload"": false }";
+            Setup(uri: expectedUri, responseContent: expectedResponseContent);
+
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            Accounts.Balance balance;
+            if (passCreds)
+            {
+                balance = await client.AccountClient.GetAccountBalanceAsync(creds);
+            }
+            else
+            {
+                balance = await client.AccountClient.GetAccountBalanceAsync();
+            }
+
+            //ASSERT
+            Assert.Equal(3.14159m, balance.Value);
+            Assert.False(balance.AutoReload);
+        }
+
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
@@ -60,6 +87,39 @@ namespace Vonage.Test.Unit
                 result = client.AccountClient.ChangeAccountSettings(new Accounts.AccountSettingsRequest { MoCallBackUrl = "https://example.com/webhooks/inbound-sms", DrCallBackUrl = "https://example.com/webhooks/delivery-receipt" });
             }
             
+
+            //ASSERT
+            Assert.Equal("https://example.com/webhooks/delivery-receipt", result.DrCallbackurl);
+            Assert.Equal("https://example.com/webhooks/inbound-sms", result.MoCallbackUrl);
+            Assert.Equal(4, result.MaxCallsPerSecond);
+            Assert.Equal(30, result.MaxInboundRequest);
+            Assert.Equal(15, result.MaxOutboundRequest);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async void SetSettingsAsync(bool passCreds)
+        {
+            //ARRANGE
+            var expectedUri = $"{RestUrl}/account/settings";
+            var expectedRequestContents = $"moCallBackUrl={HttpUtility.UrlEncode("https://example.com/webhooks/inbound-sms")}&drCallBackUrl={HttpUtility.UrlEncode("https://example.com/webhooks/delivery-receipt")}&api_key={ApiKey}&api_secret={ApiSecret}&";
+            var expectedResponseContent = @"{""mo-callback-url"": ""https://example.com/webhooks/inbound-sms"",""dr-callback-url"": ""https://example.com/webhooks/delivery-receipt"",""max-outbound-request"": 15,""max-inbound-request"": 30,""max-calls-per-second"": 4}";
+            Setup(uri: expectedUri, responseContent: expectedResponseContent, requestContent: expectedRequestContents);
+
+            //ACT
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            Accounts.AccountSettingsResult result;
+            if (passCreds)
+            {
+                result = await client.AccountClient.ChangeAccountSettingsAsync(new Accounts.AccountSettingsRequest { MoCallBackUrl = "https://example.com/webhooks/inbound-sms", DrCallBackUrl = "https://example.com/webhooks/delivery-receipt" }, creds);
+            }
+            else
+            {
+                result = await client.AccountClient.ChangeAccountSettingsAsync(new Accounts.AccountSettingsRequest { MoCallBackUrl = "https://example.com/webhooks/inbound-sms", DrCallBackUrl = "https://example.com/webhooks/delivery-receipt" });
+            }
+
 
             //ASSERT
             Assert.Equal("https://example.com/webhooks/delivery-receipt", result.DrCallbackurl);
@@ -98,6 +158,32 @@ namespace Vonage.Test.Unit
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        public async void TopUpAsync(bool passCreds)
+        {
+            //ARRANGE            
+            var expectedUri = $"{RestUrl}/account/top-up?trx=00X123456Y7890123Z&api_key={ApiKey}&api_secret={ApiSecret}&";
+            var expectedResponseContent = @"{""response"":""abc123""}";
+            Setup(uri: expectedUri, responseContent: expectedResponseContent);
+
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            //Act
+            var client = new VonageClient(creds);
+            Accounts.TopUpResult response;
+            if (passCreds)
+            {
+                response = await client.AccountClient.TopUpAccountBalanceAsync(new Accounts.TopUpRequest { Trx = "00X123456Y7890123Z" }, creds);
+            }
+            else
+            {
+                response = await client.AccountClient.TopUpAccountBalanceAsync(new Accounts.TopUpRequest { Trx = "00X123456Y7890123Z" });
+            }
+
+            Assert.Equal("abc123", response.Response);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
         public void GetNumbers(bool passCreds)
         {
             //ARRANGE
@@ -116,6 +202,37 @@ namespace Vonage.Test.Unit
             {
                 numbers = client.NumbersClient.GetOwnedNumbers(new Numbers.NumberSearchRequest());
             }            
+
+            //ASSERT
+            Assert.Equal(1, numbers.Count);
+            Assert.Equal("17775551212", numbers.Numbers[0].Msisdn);
+            Assert.Equal("US", numbers.Numbers[0].Country);
+            Assert.Equal("mobile-lvn", numbers.Numbers[0].Type);
+            Assert.Equal("VOICE", numbers.Numbers[0].Features.First());
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async void GetNumbersAsync(bool passCreds)
+        {
+            //ARRANGE
+            var expectedUri = $"{RestUrl}/account/numbers?api_key={ApiKey}&api_secret={ApiSecret}&";
+            var expectedResponseContent = @"{""count"":1,""numbers"":[{""country"":""US"",""msisdn"":""17775551212"",""type"":""mobile-lvn"",""features"":[""VOICE"",""SMS""]}]}";
+            Setup(uri: expectedUri, responseContent: expectedResponseContent);
+
+            //Act
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            Numbers.NumbersSearchResponse numbers;
+            if (passCreds)
+            {
+                numbers = await client.NumbersClient.GetOwnedNumbersAsync(new Numbers.NumberSearchRequest(), creds);
+            }
+            else
+            {
+                numbers = await client.NumbersClient.GetOwnedNumbersAsync(new Numbers.NumberSearchRequest());
+            }
 
             //ASSERT
             Assert.Equal(1, numbers.Count);
@@ -178,6 +295,56 @@ namespace Vonage.Test.Unit
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        public async void RetrieveApiSecretsAsync(bool passCreds)
+        {
+            //ARRANGE            
+            var expectedResponse = @"{
+                  ""_links"": {
+                    ""self"": {
+                        ""href"": ""abc123""
+                      }
+                  },
+                  ""_embedded"": {
+                    ""secrets"": [
+                      {
+                        ""_links"": {
+                          ""self"": {
+                            ""href"": ""abc123""
+                          }
+                        },
+                        ""id"": ""ad6dc56f-07b5-46e1-a527-85530e625800"",
+                        ""created_at"": ""2017-03-02T16:34:49Z""
+                      }
+                    ]
+                  }
+                }";
+            var expectedUri = $"https://api.nexmo.com/accounts/{ApiKey}/secrets";
+            Setup(expectedUri, expectedResponse);
+
+            //ACT
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            Accounts.SecretsRequestResult secrets;
+            if (passCreds)
+            {
+                secrets = await client.AccountClient.RetrieveApiSecretsAsync(ApiKey, creds);
+            }
+            else
+            {
+                secrets = await client.AccountClient.RetrieveApiSecretsAsync(ApiKey);
+            }
+
+
+            //ASSERT
+            Assert.Equal("ad6dc56f-07b5-46e1-a527-85530e625800", secrets.Embedded.Secrets[0].Id);
+            Assert.Equal("2017-03-02T16:34:49Z", secrets.Embedded.Secrets[0].CreatedAt);
+            Assert.Equal("abc123", secrets.Embedded.Secrets[0].Links.Self.Href);
+            Assert.Equal("abc123", secrets.Links.Self.Href);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
         public void CreateApiSecret(bool passCreds)
         {            
             //ARRANGE            
@@ -211,6 +378,44 @@ namespace Vonage.Test.Unit
             Assert.Equal("ad6dc56f-07b5-46e1-a527-85530e625800", secret.Id);
             Assert.Equal("2017-03-02T16:34:49Z", secret.CreatedAt);
             Assert.Equal("abc123", secret.Links.Self.Href);            
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async void CreateApiSecretAsync(bool passCreds)
+        {
+            //ARRANGE            
+            var expectedUri = $"https://api.nexmo.com/accounts/{ApiKey}/secrets";
+            var expectedResponse = @"{
+                  ""_links"": {
+                    ""self"": {
+                           ""href"": ""abc123""
+                      }
+                    },
+                  ""id"": ""ad6dc56f-07b5-46e1-a527-85530e625800"",
+                  ""created_at"": ""2017-03-02T16:34:49Z""
+                }";
+            Setup(expectedUri, expectedResponse);
+
+            //ACT
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            Accounts.Secret secret;
+            if (passCreds)
+            {
+                secret = await client.AccountClient.CreateApiSecretAsync(new Accounts.CreateSecretRequest { Secret = "password" }, ApiKey, creds);
+            }
+            else
+            {
+                secret = await client.AccountClient.CreateApiSecretAsync(new Accounts.CreateSecretRequest { Secret = "password" }, ApiKey);
+            }
+
+
+            //ASSERT
+            Assert.Equal("ad6dc56f-07b5-46e1-a527-85530e625800", secret.Id);
+            Assert.Equal("2017-03-02T16:34:49Z", secret.CreatedAt);
+            Assert.Equal("abc123", secret.Links.Self.Href);
         }
 
         [Theory]
@@ -257,6 +462,47 @@ namespace Vonage.Test.Unit
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        public async void RetrieveSecretAsync(bool passCreds)
+        {
+
+            //ARRANGE            
+            var secretId = "ad6dc56f-07b5-46e1-a527-85530e625800";
+            var expectedUri = $"https://api.nexmo.com/accounts/{ApiKey}/secrets/{secretId}";
+            var expectedResponse = @"{
+                  ""_links"": {
+                    ""self"": {
+                           ""href"": ""abc123""
+                      }
+                    },
+                  ""id"": ""ad6dc56f-07b5-46e1-a527-85530e625800"",
+                  ""created_at"": ""2017-03-02T16:34:49Z""
+                }";
+            Setup(expectedUri, expectedResponse);
+
+            //ACT
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+
+            var client = new VonageClient(creds);
+            Accounts.Secret secret;
+            if (passCreds)
+            {
+                secret = await client.AccountClient.RetrieveApiSecretAsync(secretId, ApiKey, creds);
+            }
+            else
+            {
+                secret = await client.AccountClient.RetrieveApiSecretAsync(secretId, ApiKey);
+            }
+
+
+            //ASSERT
+            Assert.Equal(secretId, secret.Id);
+            Assert.Equal("2017-03-02T16:34:49Z", secret.CreatedAt);
+            Assert.Equal("abc123", secret.Links.Self.Href);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
         public void RevokeSecret(bool passCreds)
         {
             //ARRANGE            
@@ -278,6 +524,35 @@ namespace Vonage.Test.Unit
                 response = client.AccountClient.RevokeApiSecret(secretId, ApiKey);
             }
             
+
+            //ASSERT
+            Assert.True(response);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async void RevokeSecretAsync(bool passCreds)
+        {
+            //ARRANGE            
+            var secretId = "ad6dc56f-07b5-46e1-a527-85530e625800";
+            var expectedUri = $"https://api.nexmo.com/accounts/{ApiKey}/secrets/{secretId}";
+            var expectedResponse = @"";
+            Setup(expectedUri, expectedResponse);
+
+            //ACT
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            bool response;
+            if (passCreds)
+            {
+                response = await client.AccountClient.RevokeApiSecretAsync(secretId, ApiKey, creds);
+            }
+            else
+            {
+                response = await client.AccountClient.RevokeApiSecretAsync(secretId, ApiKey);
+            }
+
 
             //ASSERT
             Assert.True(response);

--- a/Vonage.Test.Unit/ApplicationTests.cs
+++ b/Vonage.Test.Unit/ApplicationTests.cs
@@ -134,6 +134,123 @@ namespace Vonage.Test.Unit
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        public async void CreateApplicationAsync(bool passCreds)
+        {
+            //ARRANGE
+            var uri = $"{ApiUrl}/v2/applications";
+            var expectedResponse = @"{
+                  ""id"": ""78d335fa323d01149c3dd6f0d48968cf"",
+                  ""name"": ""My Application"",
+                  ""capabilities"": {
+                                ""voice"": {
+                                    ""webhooks"": {
+                                        ""answer_url"": {
+                                            ""address"": ""https://example.com/webhooks/answer"",
+                          ""http_method"": ""GET""
+                                        },
+                        ""fallback_answer_url"": {
+                                            ""address"": ""https://fallback.example.com/webhooks/answer"",
+                          ""http_method"": ""GET""
+                        },
+                        ""event_url"": {
+                                            ""address"": ""https://example.com/webhooks/event"",
+                          ""http_method"": ""POST""
+                        }
+                                    }
+                                },
+                    ""messages"": {
+                                    ""webhooks"": {
+                                        ""inbound_url"": {
+                                            ""address"": ""https://example.com/webhooks/inbound"",
+                          ""http_method"": ""POST""
+                                        },
+                        ""status_url"": {
+                                            ""address"": ""https://example.com/webhooks/status"",
+                          ""http_method"": ""POST""
+                        }
+                                    }
+                                },
+                    ""rtc"": {
+                                    ""webhooks"": {
+                                        ""event_url"": {
+                                            ""address"": ""https://example.com/webhooks/event"",
+                          ""http_method"": ""POST""
+                                        }
+                                    }
+                                },
+                    ""vbc"": { }
+                            },
+                  ""keys"": {
+                                ""public_key"": ""-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCA\nKOxjsU4pf/sMFi9N0jqcSLcjxu33G\nd/vynKnlw9SENi+UZR44GdjGdmfm1\ntL1eA7IBh2HNnkYXnAwYzKJoa4eO3\n0kYWekeIZawIwe/g9faFgkev+1xsO\nOUNhPx2LhuLmgwWSRS4L5W851Xe3f\nUQIDAQAB\n-----END PUBLIC KEY-----\n"",
+                    ""private_key"": ""-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFA\nASCBKcwggSjAgEAAoIBAQDEPpvi+3\nRH1efQ\\nkveWzZDrNNoEXmBw61w+O\n0u/N36tJnN5XnYecU64yHzu2ByEr0\n7iIvYbavFnADwl\\nHMTJwqDQakpa3\n8/SFRnTDq3zronvNZ6nOp7S6K7pcZ\nrw/CvrL6hXT1x7cGBZ4jPx\\nqhjqY\nuJPgZD7OVB69oYOV92vIIJ7JLYwqb\n-----END PRIVATE KEY-----\n""
+                  }
+                        }";
+            var expectedRequestContent = @"{""name"":""My Application"",""capabilities"":{""voice"":{""webhooks"":{""answer_url"":{""http_method"":""GET"",""address"":""https://example.com/webhooks/answer""},""event_url"":{""http_method"":""POST"",""address"":""https://example.com/webhooks/events""},""fallback_answer_url"":{""http_method"":""GET"",""address"":""https://fallback.example.com/webhooks/answer""}}},""rtc"":{""webhooks"":{""event_url"":{""http_method"":""POST"",""address"":""https://example.com/webhooks/events""}}},""vbc"":{},""messages"":{""webhooks"":{""inbound_url"":{""http_method"":""POST"",""address"":""https://example.com/webhooks/inbound""},""status_url"":{""http_method"":""POST"",""address"":""https://example.com/webhooks/status""}}}},""keys"":{""public_key"":""-----BEGIN PUBLIC KEY-----\\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwxyBT5FqzibSYK0vB+Gr\\nP+YlyYqsx4lvAmotTwmObZEhTWNAdU0p9hrnNXWX1Gy5O0NDIue40SUhYhJT5r4x\\nugbpNA/1KJauB8VQjetKr9bu697yskz2+EuKa2D9e6N2EMY6PD1tJWmeMmddM1tW\\n2DAXuYo7/xsDWIIA6egCTzyShNvzlKo5081t41xVVsPjsWN887Xp1KYfE0IMGV2j\\n8Nwdtw/MQfP/7Qz7i9VXb7bgx0LEg84dWsnz8u3VZ3IQHlydzPX/2iw7e4pc+k27\\nOU1SkmPn/2JtfFFS2LJpcO/FmdSyNnyHezNPyzNRLVbE0sJJ1tEhxi9GZc1I+Oc4\\ndwIDAQAB\\n-----END PUBLIC KEY-----\\n""}}";
+
+            Setup(uri: uri, responseContent: expectedResponse, requestContent: expectedRequestContent);
+
+            //ACT
+            var messagesWebhooks = new Dictionary<Common.Webhook.Type, Common.Webhook>();
+            messagesWebhooks.Add(Common.Webhook.Type.inbound_url, new Common.Webhook { Address = "https://example.com/webhooks/inbound", Method = "POST" });
+            messagesWebhooks.Add(Common.Webhook.Type.status_url, new Common.Webhook { Address = "https://example.com/webhooks/status", Method = "POST" });
+            var messagesCapability = new Messages(messagesWebhooks);
+
+            var rtcWebhooks = new Dictionary<Common.Webhook.Type, Common.Webhook>();
+            rtcWebhooks.Add(Common.Webhook.Type.event_url, new Common.Webhook { Address = "https://example.com/webhooks/events", Method = "POST" });
+            var rtcCapability = new Rtc(rtcWebhooks);
+
+            var voiceWebhooks = new Dictionary<Common.Webhook.Type, Common.Webhook>();
+            voiceWebhooks.Add(Common.Webhook.Type.answer_url, new Common.Webhook { Address = "https://example.com/webhooks/answer", Method = "GET" });
+            voiceWebhooks.Add(Common.Webhook.Type.event_url, new Common.Webhook { Address = "https://example.com/webhooks/events", Method = "POST" });
+            voiceWebhooks.Add(Common.Webhook.Type.fallback_answer_url, new Common.Webhook { Address = "https://fallback.example.com/webhooks/answer", Method = "GET" });
+            var voiceCapability = new Applications.Capabilities.Voice(voiceWebhooks);
+            var json = JsonConvert.SerializeObject(voiceCapability);
+            var vbcCapability = new Vbc();
+
+            var capabilities = new ApplicationCapabilities { Messages = messagesCapability, Rtc = rtcCapability, Voice = voiceCapability, Vbc = vbcCapability };
+            var keys = new Applications.Keys
+            {
+                PublicKey = PUBLIC_KEY
+            };
+            var request = new CreateApplicationRequest { Capabilities = capabilities, Keys = keys, Name = "My Application" };
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            Application response;
+            if (passCreds)
+            {
+                response = await client.ApplicationClient.CreateApplicaitonAsync(request);
+            }
+            else
+            {
+                response = await client.ApplicationClient.CreateApplicaitonAsync(request, creds);
+            }
+
+
+            Assert.Equal("78d335fa323d01149c3dd6f0d48968cf", response.Id);
+            Assert.Equal("https://example.com/webhooks/answer", response.Capabilities.Voice.Webhooks[Common.Webhook.Type.answer_url].Address);
+            Assert.Equal("GET", response.Capabilities.Voice.Webhooks[Common.Webhook.Type.answer_url].Method);
+
+            Assert.Equal("https://fallback.example.com/webhooks/answer", response.Capabilities.Voice.Webhooks[Common.Webhook.Type.fallback_answer_url].Address);
+            Assert.Equal("GET", response.Capabilities.Voice.Webhooks[Common.Webhook.Type.fallback_answer_url].Method);
+
+            Assert.Equal("https://example.com/webhooks/event", response.Capabilities.Voice.Webhooks[Common.Webhook.Type.event_url].Address);
+            Assert.Equal("POST", response.Capabilities.Voice.Webhooks[Common.Webhook.Type.event_url].Method);
+
+            Assert.Equal("https://example.com/webhooks/inbound", response.Capabilities.Messages.Webhooks[Common.Webhook.Type.inbound_url].Address);
+            Assert.Equal("POST", response.Capabilities.Messages.Webhooks[Common.Webhook.Type.inbound_url].Method);
+
+            Assert.Equal("https://example.com/webhooks/status", response.Capabilities.Messages.Webhooks[Common.Webhook.Type.status_url].Address);
+            Assert.Equal("POST", response.Capabilities.Messages.Webhooks[Common.Webhook.Type.status_url].Method);
+
+            Assert.Equal("https://example.com/webhooks/event", response.Capabilities.Rtc.Webhooks[Common.Webhook.Type.event_url].Address);
+            Assert.Equal("POST", response.Capabilities.Rtc.Webhooks[Common.Webhook.Type.event_url].Method);
+
+            Assert.Equal("My Application", response.Name);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
         public void UpdateApplication(bool passCredentials)
         {
             var id = "78d335fa323d01149c3dd6f0d48968cf";
@@ -224,6 +341,122 @@ namespace Vonage.Test.Unit
                 response = client.ApplicationClient.UpdateApplication(id, application,creds);
             }
             
+
+            Assert.Equal("78d335fa323d01149c3dd6f0d48968cf", response.Id);
+            Assert.Equal("https://example.com/webhooks/answer", response.Capabilities.Voice.Webhooks[Common.Webhook.Type.answer_url].Address);
+            Assert.Equal("GET", response.Capabilities.Voice.Webhooks[Common.Webhook.Type.answer_url].Method);
+
+            Assert.Equal("https://fallback.example.com/webhooks/answer", response.Capabilities.Voice.Webhooks[Common.Webhook.Type.fallback_answer_url].Address);
+            Assert.Equal("GET", response.Capabilities.Voice.Webhooks[Common.Webhook.Type.fallback_answer_url].Method);
+
+            Assert.Equal("https://example.com/webhooks/event", response.Capabilities.Voice.Webhooks[Common.Webhook.Type.event_url].Address);
+            Assert.Equal("POST", response.Capabilities.Voice.Webhooks[Common.Webhook.Type.event_url].Method);
+
+            Assert.Equal("https://example.com/webhooks/inbound", response.Capabilities.Messages.Webhooks[Common.Webhook.Type.inbound_url].Address);
+            Assert.Equal("POST", response.Capabilities.Messages.Webhooks[Common.Webhook.Type.inbound_url].Method);
+
+            Assert.Equal("https://example.com/webhooks/status", response.Capabilities.Messages.Webhooks[Common.Webhook.Type.status_url].Address);
+            Assert.Equal("POST", response.Capabilities.Messages.Webhooks[Common.Webhook.Type.status_url].Method);
+
+            Assert.Equal("https://example.com/webhooks/event", response.Capabilities.Rtc.Webhooks[Common.Webhook.Type.event_url].Address);
+            Assert.Equal("POST", response.Capabilities.Rtc.Webhooks[Common.Webhook.Type.event_url].Method);
+
+            Assert.Equal("My Application", response.Name);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async void UpdateApplicationAsync(bool passCredentials)
+        {
+            var id = "78d335fa323d01149c3dd6f0d48968cf";
+            var uri = $"{ApiUrl}/v2/applications/{id}";
+            var expectedResponse = @"{
+                  ""id"": ""78d335fa323d01149c3dd6f0d48968cf"",
+                  ""name"": ""My Application"",
+                  ""capabilities"": {
+                                ""voice"": {
+                                    ""webhooks"": {
+                                        ""answer_url"": {
+                                            ""address"": ""https://example.com/webhooks/answer"",
+                          ""http_method"": ""GET""
+                                        },
+                        ""fallback_answer_url"": {
+                                            ""address"": ""https://fallback.example.com/webhooks/answer"",
+                          ""http_method"": ""GET""
+                        },
+                        ""event_url"": {
+                                            ""address"": ""https://example.com/webhooks/event"",
+                          ""http_method"": ""POST""
+                        }
+                                    }
+                                },
+                    ""messages"": {
+                                    ""webhooks"": {
+                                        ""inbound_url"": {
+                                            ""address"": ""https://example.com/webhooks/inbound"",
+                          ""http_method"": ""POST""
+                                        },
+                        ""status_url"": {
+                                            ""address"": ""https://example.com/webhooks/status"",
+                          ""http_method"": ""POST""
+                        }
+                                    }
+                                },
+                    ""rtc"": {
+                                    ""webhooks"": {
+                                        ""event_url"": {
+                                            ""address"": ""https://example.com/webhooks/event"",
+                          ""http_method"": ""POST""
+                                        }
+                                    }
+                                },
+                    ""vbc"": { }
+                            },
+                  ""keys"": {
+                                ""public_key"": ""-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCA\nKOxjsU4pf/sMFi9N0jqcSLcjxu33G\nd/vynKnlw9SENi+UZR44GdjGdmfm1\ntL1eA7IBh2HNnkYXnAwYzKJoa4eO3\n0kYWekeIZawIwe/g9faFgkev+1xsO\nOUNhPx2LhuLmgwWSRS4L5W851Xe3f\nUQIDAQAB\n-----END PUBLIC KEY-----\n"",
+                    ""private_key"": ""-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFA\nASCBKcwggSjAgEAAoIBAQDEPpvi+3\nRH1efQ\\nkveWzZDrNNoEXmBw61w+O\n0u/N36tJnN5XnYecU64yHzu2ByEr0\n7iIvYbavFnADwl\\nHMTJwqDQakpa3\n8/SFRnTDq3zronvNZ6nOp7S6K7pcZ\nrw/CvrL6hXT1x7cGBZ4jPx\\nqhjqY\nuJPgZD7OVB69oYOV92vIIJ7JLYwqb\n-----END PRIVATE KEY-----\n""
+                  }
+                        }";
+            var expectedRequestContent = @"{""name"":""My Application"",""capabilities"":{""voice"":{""webhooks"":{""answer_url"":{""http_method"":""GET"",""address"":""https://example.com/webhooks/answer""},""event_url"":{""http_method"":""POST"",""address"":""https://example.com/webhooks/events""},""fallback_answer_url"":{""http_method"":""GET"",""address"":""https://fallback.example.com/webhooks/answer""}}},""rtc"":{""webhooks"":{""event_url"":{""http_method"":""POST"",""address"":""https://example.com/webhooks/events""}}},""vbc"":{},""messages"":{""webhooks"":{""inbound_url"":{""http_method"":""POST"",""address"":""https://example.com/webhooks/inbound""},""status_url"":{""http_method"":""POST"",""address"":""https://example.com/webhooks/status""}}}},""keys"":{""public_key"":""-----BEGIN PUBLIC KEY-----\\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwxyBT5FqzibSYK0vB+Gr\\nP+YlyYqsx4lvAmotTwmObZEhTWNAdU0p9hrnNXWX1Gy5O0NDIue40SUhYhJT5r4x\\nugbpNA/1KJauB8VQjetKr9bu697yskz2+EuKa2D9e6N2EMY6PD1tJWmeMmddM1tW\\n2DAXuYo7/xsDWIIA6egCTzyShNvzlKo5081t41xVVsPjsWN887Xp1KYfE0IMGV2j\\n8Nwdtw/MQfP/7Qz7i9VXb7bgx0LEg84dWsnz8u3VZ3IQHlydzPX/2iw7e4pc+k27\\nOU1SkmPn/2JtfFFS2LJpcO/FmdSyNnyHezNPyzNRLVbE0sJJ1tEhxi9GZc1I+Oc4\\ndwIDAQAB\\n-----END PUBLIC KEY-----\\n""}}";
+            Setup(uri: uri, responseContent: expectedResponse, requestContent: expectedRequestContent);
+
+            //ACT
+            var messagesWebhooks = new Dictionary<Common.Webhook.Type, Common.Webhook>();
+            messagesWebhooks.Add(Common.Webhook.Type.inbound_url, new Common.Webhook { Address = "https://example.com/webhooks/inbound", Method = "POST" });
+            messagesWebhooks.Add(Common.Webhook.Type.status_url, new Common.Webhook { Address = "https://example.com/webhooks/status", Method = "POST" });
+            var messagesCapability = new Messages(messagesWebhooks);
+
+            var rtcWebhooks = new Dictionary<Common.Webhook.Type, Common.Webhook>();
+            rtcWebhooks.Add(Common.Webhook.Type.event_url, new Common.Webhook { Address = "https://example.com/webhooks/events", Method = "POST" });
+            var rtcCapability = new Rtc(rtcWebhooks);
+
+            var voiceWebhooks = new Dictionary<Common.Webhook.Type, Common.Webhook>();
+            voiceWebhooks.Add(Common.Webhook.Type.answer_url, new Common.Webhook { Address = "https://example.com/webhooks/answer", Method = "GET" });
+            voiceWebhooks.Add(Common.Webhook.Type.event_url, new Common.Webhook { Address = "https://example.com/webhooks/events", Method = "POST" });
+            voiceWebhooks.Add(Common.Webhook.Type.fallback_answer_url, new Common.Webhook { Address = "https://fallback.example.com/webhooks/answer", Method = "GET" });
+            var voiceCapability = new Applications.Capabilities.Voice(voiceWebhooks);
+            var json = JsonConvert.SerializeObject(voiceCapability);
+            var vbcCapability = new Vbc();
+
+            var capabilities = new ApplicationCapabilities { Messages = messagesCapability, Rtc = rtcCapability, Voice = voiceCapability, Vbc = vbcCapability };
+            var keys = new Applications.Keys
+            {
+                PublicKey = PUBLIC_KEY
+            };
+            var application = new CreateApplicationRequest { Capabilities = capabilities, Keys = keys, Name = "My Application" };
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            Application response;
+            if (passCredentials)
+            {
+                response = await client.ApplicationClient.UpdateApplicationAsync(id, application);
+            }
+            else
+            {
+                response = await client.ApplicationClient.UpdateApplicationAsync(id, application, creds);
+            }
+
 
             Assert.Equal("78d335fa323d01149c3dd6f0d48968cf", response.Id);
             Assert.Equal("https://example.com/webhooks/answer", response.Capabilities.Voice.Webhooks[Common.Webhook.Type.answer_url].Address);
@@ -364,6 +597,122 @@ namespace Vonage.Test.Unit
         }
 
         [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, true)]
+        public  async void ListApplicationsAsync(bool passCreds, bool passParameters)
+        {
+            var expectedResult = @"{
+                  ""page_size"": 10,
+                  ""page"": 1,
+                  ""total_items"": 6,
+                  ""total_pages"": 1,
+                  ""_embedded"": {
+                                ""applications"": [
+                                  {
+                        ""id"": ""78d335fa323d01149c3dd6f0d48968cf"",
+                                    ""name"": ""My Application"",
+                                    ""capabilities"": {
+                          ""voice"": {
+                            ""webhooks"": {
+                              ""answer_url"": {
+                                ""address"": ""https://example.com/webhooks/answer"",
+                                            ""http_method"": ""GET""
+                              },
+                              ""fallback_answer_url"": {
+                                ""address"": ""https://fallback.example.com/webhooks/answer"",
+                                ""http_method"": ""GET""
+                              },
+                              ""event_url"": {
+                                ""address"": ""https://example.com/webhooks/event"",
+                                ""http_method"": ""POST""
+                              }
+                            }
+                          },
+                          ""messages"": {
+                            ""webhooks"": {
+                              ""inbound_url"": {
+                                ""address"": ""https://example.com/webhooks/inbound"",
+                                ""http_method"": ""POST""
+                              },
+                              ""status_url"": {
+                                ""address"": ""https://example.com/webhooks/status"",
+                                ""http_method"": ""POST""
+                              }
+                            }
+                          },
+                          ""rtc"": {
+                            ""webhooks"": {
+                              ""event_url"": {
+                                ""address"": ""https://example.com/webhooks/event"",
+                                ""http_method"": ""POST""
+                              }
+                            }
+                          },
+                          ""vbc"": {}
+                        }
+                      }
+                    ]
+                  }
+                }";
+            string expectedUri;
+            ListApplicationsRequest request;
+            if (passParameters)
+            {
+                expectedUri = $"{ApiUrl}/v2/applications?page_size=10&page=1&";
+                request = new ListApplicationsRequest { Page = 1, PageSize = 10 };
+            }
+            else
+            {
+                expectedUri = $"{ApiUrl}/v2/applications";
+                request = new ListApplicationsRequest();
+            }
+            Setup(expectedUri, expectedResult);
+
+            //Act
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+
+
+            ApplicationPage applications;
+            if (passCreds)
+            {
+                applications = await client.ApplicationClient.ListApplicationsAsync(request, creds);
+            }
+            else
+            {
+                applications = await client.ApplicationClient.ListApplicationsAsync(request);
+            }
+
+            Application application = applications.Embedded.Applications[0];
+
+            Assert.Equal("78d335fa323d01149c3dd6f0d48968cf", application.Id);
+            Assert.Equal("https://example.com/webhooks/answer", application.Capabilities.Voice.Webhooks[Common.Webhook.Type.answer_url].Address);
+            Assert.Equal("GET", application.Capabilities.Voice.Webhooks[Common.Webhook.Type.answer_url].Method);
+
+            Assert.Equal("https://fallback.example.com/webhooks/answer", application.Capabilities.Voice.Webhooks[Common.Webhook.Type.fallback_answer_url].Address);
+            Assert.Equal("GET", application.Capabilities.Voice.Webhooks[Common.Webhook.Type.fallback_answer_url].Method);
+
+            Assert.Equal("https://example.com/webhooks/event", application.Capabilities.Voice.Webhooks[Common.Webhook.Type.event_url].Address);
+            Assert.Equal("POST", application.Capabilities.Voice.Webhooks[Common.Webhook.Type.event_url].Method);
+
+            Assert.Equal("https://example.com/webhooks/inbound", application.Capabilities.Messages.Webhooks[Common.Webhook.Type.inbound_url].Address);
+            Assert.Equal("POST", application.Capabilities.Messages.Webhooks[Common.Webhook.Type.inbound_url].Method);
+
+            Assert.Equal("https://example.com/webhooks/status", application.Capabilities.Messages.Webhooks[Common.Webhook.Type.status_url].Address);
+            Assert.Equal("POST", application.Capabilities.Messages.Webhooks[Common.Webhook.Type.status_url].Method);
+
+            Assert.Equal("https://example.com/webhooks/event", application.Capabilities.Rtc.Webhooks[Common.Webhook.Type.event_url].Address);
+            Assert.Equal("POST", application.Capabilities.Rtc.Webhooks[Common.Webhook.Type.event_url].Method);
+
+            Assert.Equal("My Application", application.Name);
+
+            Assert.Equal(6, applications.TotalItems);
+            Assert.Equal(1, applications.TotalPages);
+            Assert.Equal(10, applications.PageSize);
+            Assert.Equal(1, applications.Page);
+        }
+
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public void GetApplication(bool passCreds)
@@ -457,6 +806,97 @@ namespace Vonage.Test.Unit
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        public async void GetApplicationAsync(bool passCreds)
+        {
+            var id = "78d335fa323d01149c3dd6f0d48968cf";
+            var uri = $"{ApiUrl}/v2/applications/{id}";
+            var expectedResponse = @"{
+                  ""id"": ""78d335fa323d01149c3dd6f0d48968cf"",
+                  ""name"": ""My Application"",
+                  ""capabilities"": {
+                                ""voice"": {
+                                    ""webhooks"": {
+                                        ""answer_url"": {
+                                            ""address"": ""https://example.com/webhooks/answer"",
+                          ""http_method"": ""GET""
+                                        },
+                        ""fallback_answer_url"": {
+                                            ""address"": ""https://fallback.example.com/webhooks/answer"",
+                          ""http_method"": ""GET""
+                        },
+                        ""event_url"": {
+                                            ""address"": ""https://example.com/webhooks/event"",
+                          ""http_method"": ""POST""
+                        }
+                                    }
+                                },
+                    ""messages"": {
+                                    ""webhooks"": {
+                                        ""inbound_url"": {
+                                            ""address"": ""https://example.com/webhooks/inbound"",
+                          ""http_method"": ""POST""
+                                        },
+                        ""status_url"": {
+                                            ""address"": ""https://example.com/webhooks/status"",
+                          ""http_method"": ""POST""
+                        }
+                                    }
+                                },
+                    ""rtc"": {
+                                    ""webhooks"": {
+                                        ""event_url"": {
+                                            ""address"": ""https://example.com/webhooks/event"",
+                          ""http_method"": ""POST""
+                                        }
+                                    }
+                                },
+                    ""vbc"": { }
+                            },
+                  ""keys"": {
+                                ""public_key"": ""-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCA\nKOxjsU4pf/sMFi9N0jqcSLcjxu33G\nd/vynKnlw9SENi+UZR44GdjGdmfm1\ntL1eA7IBh2HNnkYXnAwYzKJoa4eO3\n0kYWekeIZawIwe/g9faFgkev+1xsO\nOUNhPx2LhuLmgwWSRS4L5W851Xe3f\nUQIDAQAB\n-----END PUBLIC KEY-----\n"",
+                    ""private_key"": ""-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFA\nASCBKcwggSjAgEAAoIBAQDEPpvi+3\nRH1efQ\\nkveWzZDrNNoEXmBw61w+O\n0u/N36tJnN5XnYecU64yHzu2ByEr0\n7iIvYbavFnADwl\\nHMTJwqDQakpa3\n8/SFRnTDq3zronvNZ6nOp7S6K7pcZ\nrw/CvrL6hXT1x7cGBZ4jPx\\nqhjqY\nuJPgZD7OVB69oYOV92vIIJ7JLYwqb\n-----END PRIVATE KEY-----\n""
+                  }
+                        }";
+            var expectedUri = $"{ApiUrl}/v2/applications/{id}";
+            Setup(expectedUri, expectedResponse);
+
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            Application application;
+            if (passCreds)
+            {
+                application = await client.ApplicationClient.GetApplicationAsync(id, creds);
+            }
+            else
+            {
+                application = await client.ApplicationClient.GetApplicationAsync(id);
+            }
+
+            Assert.Equal("78d335fa323d01149c3dd6f0d48968cf", application.Id);
+            Assert.Equal("https://example.com/webhooks/answer", application.Capabilities.Voice.Webhooks[Common.Webhook.Type.answer_url].Address);
+            Assert.Equal("GET", application.Capabilities.Voice.Webhooks[Common.Webhook.Type.answer_url].Method);
+
+            Assert.Equal("https://fallback.example.com/webhooks/answer", application.Capabilities.Voice.Webhooks[Common.Webhook.Type.fallback_answer_url].Address);
+            Assert.Equal("GET", application.Capabilities.Voice.Webhooks[Common.Webhook.Type.fallback_answer_url].Method);
+
+            Assert.Equal("https://example.com/webhooks/event", application.Capabilities.Voice.Webhooks[Common.Webhook.Type.event_url].Address);
+            Assert.Equal("POST", application.Capabilities.Voice.Webhooks[Common.Webhook.Type.event_url].Method);
+
+            Assert.Equal("https://example.com/webhooks/inbound", application.Capabilities.Messages.Webhooks[Common.Webhook.Type.inbound_url].Address);
+            Assert.Equal("POST", application.Capabilities.Messages.Webhooks[Common.Webhook.Type.inbound_url].Method);
+
+            Assert.Equal("https://example.com/webhooks/status", application.Capabilities.Messages.Webhooks[Common.Webhook.Type.status_url].Address);
+            Assert.Equal("POST", application.Capabilities.Messages.Webhooks[Common.Webhook.Type.status_url].Method);
+
+            Assert.Equal("https://example.com/webhooks/event", application.Capabilities.Rtc.Webhooks[Common.Webhook.Type.event_url].Address);
+            Assert.Equal("POST", application.Capabilities.Rtc.Webhooks[Common.Webhook.Type.event_url].Method);
+
+            Assert.Equal("My Application", application.Name);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
         public void DeleteApplication(bool passCreds)
         {
             var id = "78d335fa323d01149c3dd6f0d48968cf";
@@ -473,6 +913,29 @@ namespace Vonage.Test.Unit
             else
             {
                 result = client.ApplicationClient.DeleteApplication(id);
+            }
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async void DeleteApplicationAsync(bool passCreds)
+        {
+            var id = "78d335fa323d01149c3dd6f0d48968cf";
+            var uri = $"{ApiUrl}/v2/applications/{id}";
+            string expectedResponse = "";
+            Setup(uri, expectedResponse);
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            bool result;
+            if (passCreds)
+            {
+                result = await client.ApplicationClient.DeleteApplicationAsync(id, creds);
+            }
+            else
+            {
+                result = await client.ApplicationClient.DeleteApplicationAsync(id);
             }
             Assert.True(result);
         }

--- a/Vonage.Test.Unit/ConversionTest.cs
+++ b/Vonage.Test.Unit/ConversionTest.cs
@@ -56,5 +56,53 @@ namespace Vonage.Test.Unit
             }
             Assert.True(response);
         }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async void SmsConversionAsync(bool passCreds)
+        {
+            var expectedUri = $"${ApiUrl}/conversions/sms";
+            var expectedContent = "message-id=00A0B0C0&delivered=true&timestamp=2020-01-01+12%3A00%3A00&api_key=testkey&api_secret=testSecret&";
+            var expectedResponse = "";
+            Setup(expectedUri, expectedResponse, expectedContent);
+            var request = new Conversions.ConversionRequest { Delivered = "true", MessageId = "00A0B0C0", TimeStamp = "2020-01-01 12:00:00" };
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            bool response;
+            if (passCreds)
+            {
+                response = await client.ConversionClient.SmsConversionAsync(request, creds);
+            }
+            else
+            {
+                response = await client.ConversionClient.SmsConversionAsync(request);
+            }
+            Assert.True(response);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async void VoiceConversionAsync(bool passCreds)
+        {
+            var expectedUri = $"${ApiUrl}/conversions/sms";
+            var expectedContent = "message-id=00A0B0C0&delivered=true&timestamp=2020-01-01+12%3A00%3A00&api_key=testkey&api_secret=testSecret&";
+            var expectedResponse = "";
+            Setup(expectedUri, expectedResponse, expectedContent);
+            var request = new Conversions.ConversionRequest { Delivered = "true", MessageId = "00A0B0C0", TimeStamp = "2020-01-01 12:00:00" };
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            bool response;
+            if (passCreds)
+            {
+                response = await client.ConversionClient.VoiceConversionAsync(request, creds);
+            }
+            else
+            {
+                response = await client.ConversionClient.VoiceConversionAsync(request);
+            }
+            Assert.True(response);
+        }
     }
 }

--- a/Vonage.Test.Unit/MessagingTests.cs
+++ b/Vonage.Test.Unit/MessagingTests.cs
@@ -147,6 +147,38 @@ namespace Vonage.Test.Unit
         }
 
         [Fact]
+        public async void SendSmsTypicalUsageSimplifiedAsync()
+        {
+            var expectedResponse = @"{
+                  ""message-count"": ""1"",
+                  ""messages"": [
+                    {
+                      ""to"": ""447700900000"",
+                      ""message-id"": ""0A0000000123ABCD1"",
+                      ""status"": ""0"",
+                      ""remaining-balance"": ""3.14159265"",
+                      ""message-price"": ""0.03330000"",
+                      ""network"": ""12345"",
+                      ""account-ref"": ""customer1234""
+                    }
+                  ]
+                }";
+            var expectedUri = $"{RestUrl}/sms/json?";
+            var expectedRequestContent = $"from=AcmeInc&to=447700900000&text={HttpUtility.UrlEncode("Hello World!")}&type=text&api_key={ApiKey}&api_secret={ApiSecret}&";
+            Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var client = new VonageClient(Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret));
+            var response = await client.SmsClient.SendAnSmsAsync("AcmeInc", "447700900000", "Hello World!");
+            Assert.Equal("1", response.MessageCount);
+            Assert.Equal("447700900000", response.Messages[0].To);
+            Assert.Equal("0A0000000123ABCD1", response.Messages[0].MessageId);
+            Assert.Equal("0", response.Messages[0].Status);
+            Assert.Equal(SmsStatusCode.Success, response.Messages[0].StatusCode);
+            Assert.Equal("3.14159265", response.Messages[0].RemainingBalance);
+            Assert.Equal("12345", response.Messages[0].Network);
+            Assert.Equal("customer1234", response.Messages[0].AccountRef);
+        }
+
+        [Fact]
         public void SendSmsUnicode()
         {
             var expectedResponse = @"{

--- a/Vonage.Test.Unit/NumberInsightsTests.cs
+++ b/Vonage.Test.Unit/NumberInsightsTests.cs
@@ -69,6 +69,61 @@ namespace Vonage.Test.Unit
         [Theory]
         [InlineData(true, true)]
         [InlineData(false, false)]
+        public async void TestBasicNIRequestAsync(bool passCreds, bool kitchenSink)
+        {
+            //ARRANGE
+            var expectedUri = $"{ApiUrl}/ni/basic/json";
+            BasicNumberInsightRequest request;
+            var expectedResponseContent = "{\"status\": 0,\"status_message\": \"Success\",\"request_id\": \"ca4f82b6-73aa-43fe-8c52-874fd9ffffff\",\"international_format_number\": \"15555551212\",\"national_format_number\": \"(555) 555-1212\"," +
+                "\"country_code\": \"US\",\"country_code_iso3\": \"USA\",\"country_name\": \"United States of America\",\"country_prefix\": \"1\"}";
+
+            if (kitchenSink)
+            {
+                expectedUri += $"?number=15555551212&country=GB&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new BasicNumberInsightRequest
+                {
+                    Country = "GB",
+                    Number = "15555551212"
+                };
+            }
+            else
+            {
+                expectedUri += $"?number=15555551212&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new BasicNumberInsightRequest
+                {
+                    Number = "15555551212"
+                };
+            }
+            Setup(expectedUri, expectedResponseContent);
+
+            //ACT
+            BasicInsightResponse response;
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            if (passCreds)
+            {
+                response = await client.NumberInsightClient.GetNumberInsightBasicAsync(request, creds);
+            }
+            else
+            {
+                response = await client.NumberInsightClient.GetNumberInsightBasicAsync(request);
+            }
+
+            //ASSERT
+            Assert.Equal(0, response.Status);
+            Assert.Equal("Success", response.StatusMessage);
+            Assert.Equal("ca4f82b6-73aa-43fe-8c52-874fd9ffffff", response.RequestId);
+            Assert.Equal("15555551212", response.InternationalFormatNumber);
+            Assert.Equal("(555) 555-1212", response.NationalFormatNumber);
+            Assert.Equal("US", response.CountryCode);
+            Assert.Equal("USA", response.CountryCodeIso3);
+            Assert.Equal("United States of America", response.CountryName);
+            Assert.Equal("1", response.CountryPrefix);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
         public void TestStandardNIRequest(bool passCreds, bool kitchenSink)
         {
             //ARRANGE
@@ -144,6 +199,120 @@ namespace Vonage.Test.Unit
             else
             {
                 response = client.NumberInsightClient.GetNumberInsightStandard(request);
+            }
+            Assert.Equal("John", response.FirstName);
+            Assert.Equal(CallerType.consumer, response.CallerType);
+            Assert.Equal("Smith", response.LastName);
+            Assert.Equal("John Smith", response.CallerName);
+            Assert.Equal("Smith", response.CallerIdentity.LastName);
+            Assert.Equal("John", response.CallerIdentity.FirstName);
+            Assert.Equal("John Smith", response.CallerIdentity.CallerName);
+            Assert.Equal(CallerType.consumer, response.CallerIdentity.CallerType);
+            Assert.Equal("Acme Inc", response.Roaming.RoamingNetworkName);
+            Assert.Equal("12345", response.Roaming.RoamingNetworkCode);
+            Assert.Equal("US", response.Roaming.RoamingCountryCode);
+            Assert.Equal(RoamingStatus.roaming, response.Roaming.Status);
+            Assert.Equal(PortedStatus.not_ported, response.Ported);
+            Assert.Equal("12345", response.OriginalCarrier.NetworkCode);
+            Assert.Equal("Acme Inc", response.OriginalCarrier.Name);
+            Assert.Equal("GB", response.OriginalCarrier.Country);
+            Assert.Equal("mobile", response.OriginalCarrier.NetworkType);
+            Assert.Equal(0, response.Status);
+            Assert.Equal("Success", response.StatusMessage);
+            Assert.Equal("aaaaaaaa-bbbb-cccc-dddd-0123456789ab", response.RequestId);
+            Assert.Equal("447700900000", response.InternationalFormatNumber);
+            Assert.Equal("07700 900000", response.NationalFormatNumber);
+            Assert.Equal("GB", response.CountryCode);
+            Assert.Equal("GBR", response.CountryCodeIso3);
+            Assert.Equal("United Kingdom", response.CountryName);
+            Assert.Equal("44", response.CountryPrefix);
+            Assert.Equal("0.04000000", response.RequestPrice);
+            Assert.Equal("0.01500000", response.RefundPrice);
+            Assert.Equal("1.23456789", response.RemainingBalance);
+            Assert.Equal("12345", response.CurrentCarrier.NetworkCode);
+            Assert.Equal("Acme Inc", response.CurrentCarrier.Name);
+            Assert.Equal("GB", response.CurrentCarrier.Country);
+            Assert.Equal("mobile", response.CurrentCarrier.NetworkType);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public async void TestStandardNIRequestAsync(bool passCreds, bool kitchenSink)
+        {
+            //ARRANGE
+            var expectedResponse = @"{
+              ""status"": 0,
+              ""status_message"": ""Success"",
+              ""request_id"": ""aaaaaaaa-bbbb-cccc-dddd-0123456789ab"",
+              ""international_format_number"": ""447700900000"",
+              ""national_format_number"": ""07700 900000"",
+              ""country_code"": ""GB"",
+              ""country_code_iso3"": ""GBR"",
+              ""country_name"": ""United Kingdom"",
+              ""country_prefix"": ""44"",
+              ""request_price"": ""0.04000000"",
+              ""refund_price"": ""0.01500000"",
+              ""remaining_balance"": ""1.23456789"",
+              ""current_carrier"": {
+                ""network_code"": ""12345"",
+                ""name"": ""Acme Inc"",
+                ""country"": ""GB"",
+                ""network_type"": ""mobile""
+              },
+              ""original_carrier"": {
+                ""network_code"": ""12345"",
+                ""name"": ""Acme Inc"",
+                ""country"": ""GB"",
+                ""network_type"": ""mobile""
+              },
+              ""ported"": ""not_ported"",
+              ""roaming"": {
+                            ""status"": ""roaming"",
+                ""roaming_country_code"": ""US"",
+                ""roaming_network_code"": ""12345"",
+                ""roaming_network_name"": ""Acme Inc""
+              },
+              ""caller_identity"": {
+                            ""caller_type"": ""consumer"",
+                ""caller_name"": ""John Smith"",
+                ""first_name"": ""John"",
+                ""last_name"": ""Smith""
+              },
+              ""caller_name"": ""John Smith"",
+              ""last_name"": ""Smith"",
+              ""first_name"": ""John"",
+              ""caller_type"": ""consumer""
+            }";
+            var expectedUri = $"{ApiUrl}/ni/standard/json";
+            StandardNumberInsightRequest request;
+            if (kitchenSink)
+            {
+                expectedUri += $"?cnam=true&number=15555551212&country=GB&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new StandardNumberInsightRequest { Cnam = true, Country = "GB", Number = "15555551212" };
+            }
+            else
+            {
+                expectedUri += $"?number=15555551212&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new StandardNumberInsightRequest
+                {
+                    Number = "15555551212"
+                };
+            }
+
+            Setup(expectedUri, expectedResponse);
+
+            //ACT
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            StandardInsightResponse response;
+            if (passCreds)
+            {
+                response = await client.NumberInsightClient.GetNumberInsightStandardAsync(request, creds);
+            }
+            else
+            {
+                response = await client.NumberInsightClient.GetNumberInsightStandardAsync(request);
             }
             Assert.Equal("John", response.FirstName);
             Assert.Equal(CallerType.consumer, response.CallerType);
@@ -307,6 +476,130 @@ namespace Vonage.Test.Unit
         [Theory]
         [InlineData(true, true)]
         [InlineData(false, false)]
+        public async void TestAdvancedNIRequestSyncAsync(bool passCreds, bool kitchenSink)
+        {//ARRANGE
+            var expectedResponse = @"{
+              ""status"": 0,
+              ""status_message"": ""Success"",
+              ""request_id"": ""aaaaaaaa-bbbb-cccc-dddd-0123456789ab"",
+              ""international_format_number"": ""447700900000"",
+              ""national_format_number"": ""07700 900000"",
+              ""country_code"": ""GB"",
+              ""country_code_iso3"": ""GBR"",
+              ""country_name"": ""United Kingdom"",
+              ""country_prefix"": ""44"",
+              ""request_price"": ""0.04000000"",
+              ""refund_price"": ""0.01500000"",
+              ""remaining_balance"": ""1.23456789"",
+              ""current_carrier"": {
+                ""network_code"": ""12345"",
+                ""name"": ""Acme Inc"",
+                ""country"": ""GB"",
+                ""network_type"": ""mobile""
+              },
+              ""original_carrier"": {
+                ""network_code"": ""12345"",
+                ""name"": ""Acme Inc"",
+                ""country"": ""GB"",
+                ""network_type"": ""mobile""
+              },
+              ""ported"": ""not_ported"",
+              ""roaming"": {
+                            ""status"": ""roaming"",
+                ""roaming_country_code"": ""US"",
+                ""roaming_network_code"": ""12345"",
+                ""roaming_network_name"": ""Acme Inc""
+              },
+              ""caller_identity"": {
+                            ""caller_type"": ""consumer"",
+                ""caller_name"": ""John Smith"",
+                ""first_name"": ""John"",
+                ""last_name"": ""Smith""
+              },
+              ""caller_name"": ""John Smith"",
+              ""last_name"": ""Smith"",
+              ""first_name"": ""John"",
+              ""caller_type"": ""consumer"",
+              ""lookup_outcome"": 0,
+              ""lookup_outcome_message"": ""Success"",
+              ""valid_number"": ""valid"",
+              ""reachable"": ""reachable""
+            }";
+
+            var expectedUri = $"{ApiUrl}/ni/advanced/json";
+            AdvancedNumberInsightRequest request;
+            if (kitchenSink)
+            {
+                expectedUri += $"?ip={HttpUtility.UrlEncode("123.0.0.255")}&cnam=true&number=15555551212&country=GB&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new AdvancedNumberInsightRequest { Cnam = true, Country = "GB", Number = "15555551212", Ip = "123.0.0.255" };
+            }
+            else
+            {
+                expectedUri += $"?number=15555551212&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new AdvancedNumberInsightRequest
+                {
+                    Number = "15555551212"
+                };
+            }
+
+            Setup(expectedUri, expectedResponse);
+
+            //ACT
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            AdvancedInsightsResponse response;
+            if (passCreds)
+            {
+                response = await client.NumberInsightClient.GetNumberInsightAdvancedAsync(request, creds);
+            }
+            else
+            {
+                response = await client.NumberInsightClient.GetNumberInsightAdvancedAsync(request);
+            }
+
+            //ASSERT
+            Assert.Equal(NumberReachability.reachable, response.Reachable);
+            Assert.Equal(NumberValidity.valid, response.ValidNumber);
+            Assert.Equal("Success", response.LookupOutcomeMessage);
+            Assert.Equal(0, response.LookupOutcome);
+            Assert.Equal("John", response.FirstName);
+            Assert.Equal(CallerType.consumer, response.CallerType);
+            Assert.Equal("Smith", response.LastName);
+            Assert.Equal("John Smith", response.CallerName);
+            Assert.Equal("Smith", response.CallerIdentity.LastName);
+            Assert.Equal("John", response.CallerIdentity.FirstName);
+            Assert.Equal("John Smith", response.CallerIdentity.CallerName);
+            Assert.Equal(CallerType.consumer, response.CallerIdentity.CallerType);
+            Assert.Equal("Acme Inc", response.Roaming.RoamingNetworkName);
+            Assert.Equal("12345", response.Roaming.RoamingNetworkCode);
+            Assert.Equal("US", response.Roaming.RoamingCountryCode);
+            Assert.Equal(RoamingStatus.roaming, response.Roaming.Status);
+            Assert.Equal(PortedStatus.not_ported, response.Ported);
+            Assert.Equal("12345", response.OriginalCarrier.NetworkCode);
+            Assert.Equal("Acme Inc", response.OriginalCarrier.Name);
+            Assert.Equal("GB", response.OriginalCarrier.Country);
+            Assert.Equal("mobile", response.OriginalCarrier.NetworkType);
+            Assert.Equal(0, response.Status);
+            Assert.Equal("Success", response.StatusMessage);
+            Assert.Equal("aaaaaaaa-bbbb-cccc-dddd-0123456789ab", response.RequestId);
+            Assert.Equal("447700900000", response.InternationalFormatNumber);
+            Assert.Equal("07700 900000", response.NationalFormatNumber);
+            Assert.Equal("GB", response.CountryCode);
+            Assert.Equal("GBR", response.CountryCodeIso3);
+            Assert.Equal("United Kingdom", response.CountryName);
+            Assert.Equal("44", response.CountryPrefix);
+            Assert.Equal("0.04000000", response.RequestPrice);
+            Assert.Equal("0.01500000", response.RefundPrice);
+            Assert.Equal("1.23456789", response.RemainingBalance);
+            Assert.Equal("12345", response.CurrentCarrier.NetworkCode);
+            Assert.Equal("Acme Inc", response.CurrentCarrier.Name);
+            Assert.Equal("GB", response.CurrentCarrier.Country);
+            Assert.Equal("mobile", response.CurrentCarrier.NetworkType);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
         public void TestAdvancedAsync(bool passCreds, bool kitchenSink)
         {
             var expectedResponse = @"{
@@ -345,6 +638,57 @@ namespace Vonage.Test.Unit
             else
             {
                 response = client.NumberInsightClient.GetNumberInsightAsync(request);
+            }
+
+            //ASSERT
+            Assert.Equal("aaaaaaaa-bbbb-cccc-dddd-0123456789ab", response.RequestId);
+            Assert.Equal("447700900000", response.Number);
+            Assert.Equal("1.23456789", response.RemainingBalance);
+            Assert.Equal("0.01500000", response.RequestPrice);
+            Assert.Equal(0, response.Status);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public async void TestAdvancedAsyncAsync(bool passCreds, bool kitchenSink)
+        {
+            var expectedResponse = @"{
+              ""request_id"": ""aaaaaaaa-bbbb-cccc-dddd-0123456789ab"",
+              ""number"": ""447700900000"",
+              ""remaining_balance"": ""1.23456789"",
+              ""request_price"": ""0.01500000"",
+              ""status"": 0
+            }";
+            var expectedUri = $"{ApiUrl}/ni/advanced/async/json";
+            AdvancedNumberInsightAsynchronousRequest request;
+            if (kitchenSink)
+            {
+                expectedUri += $"?callback={HttpUtility.UrlEncode("https://example.com/callback")}&ip={HttpUtility.UrlEncode("123.0.0.255")}&cnam=true&number=15555551212&country=GB&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new AdvancedNumberInsightAsynchronousRequest { Cnam = true, Country = "GB", Number = "15555551212", Ip = "123.0.0.255", Callback = "https://example.com/callback" };
+            }
+            else
+            {
+                expectedUri += $"?callback={HttpUtility.UrlEncode("https://example.com/callback")}&number=15555551212&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new AdvancedNumberInsightAsynchronousRequest
+                {
+                    Number = "15555551212",
+                    Callback = "https://example.com/callback"
+                };
+            }
+            Setup(expectedUri, expectedResponse);
+
+            //ACT
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            AdvancedInsightsAsyncResponse response;
+            if (passCreds)
+            {
+                response = await client.NumberInsightClient.GetNumberInsightAsyncAsync(request, creds);
+            }
+            else
+            {
+                response = await client.NumberInsightClient.GetNumberInsightAsyncAsync(request);
             }
 
             //ASSERT

--- a/Vonage.Test.Unit/NumbersTests.cs
+++ b/Vonage.Test.Unit/NumbersTests.cs
@@ -67,6 +67,62 @@ namespace Vonage.Test.Unit
         }
 
         [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public async void TestSearchNumbersAsync(bool passCreds, bool kitchenSink)
+        {
+            var expetedResponse = @"{
+              ""count"": 1234,
+              ""numbers"": [
+                {
+                  ""country"": ""GB"",
+                  ""msisdn"": ""447700900000"",
+                  ""type"": ""mobile-lvn"",
+                  ""cost"": ""1.25"",
+                  ""features"": [
+                    ""VOICE"",
+                    ""SMS""
+                  ]
+                }
+              ]
+            }";
+            var expectedUri = $"{RestUrl}/number/search";
+            NumberSearchRequest request;
+            if (kitchenSink)
+            {
+                expectedUri += $"?country=GB&type=mobile-lvn&pattern=12345&search_pattern=1&features=SMS&size=10&index=1&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new NumberSearchRequest { Country = "GB", Type = "mobile-lvn", Pattern = "12345", SearchPattern = SearchPattern.Contains, Features = "SMS", Size = 10, Index = 1 };
+            }
+            else
+            {
+                expectedUri += $"?country=GB&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new NumberSearchRequest { Country = "GB" };
+            }
+            Setup(expectedUri, expetedResponse);
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+
+            NumbersSearchResponse response;
+            if (passCreds)
+            {
+                response = await client.NumbersClient.GetAvailableNumbersAsync(request, creds);
+            }
+            else
+            {
+                response = await client.NumbersClient.GetAvailableNumbersAsync(request);
+            }
+
+            var number = response.Numbers[0];
+            Assert.Equal(1234, response.Count);
+            Assert.Equal("GB", number.Country);
+            Assert.Equal("447700900000", number.Msisdn);
+            Assert.Equal("mobile-lvn", number.Type);
+            Assert.Equal("1.25", number.Cost);
+            Assert.Equal("VOICE", number.Features[0]);
+            Assert.Equal("SMS", number.Features[1]);
+        }
+
+        [Theory]
         [InlineData(true,true)]
         [InlineData(false,false)]
         public void TestBuyNumber(bool passCreds, bool kitchenSink)
@@ -111,6 +167,48 @@ namespace Vonage.Test.Unit
         [Theory]
         [InlineData(true, true)]
         [InlineData(false, false)]
+        public async void TestBuyNumberAsync(bool passCreds, bool kitchenSink)
+        {
+            var expectedResponse = @"{
+              ""error-code"": ""200"",
+              ""error-code-label"": ""success""
+            }";
+            var expectedUri = $"{RestUrl}/number/buy";
+            string expectdRequestContent = $"country=GB&msisdn=447700900000&api_key={ApiKey}&api_secret={ApiSecret}&";
+            NumberTransactionRequest request;
+
+            if (kitchenSink)
+            {
+                expectdRequestContent = $"country=GB&msisdn=447700900000&target_api_key=12345&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new NumberTransactionRequest { Country = "GB", Msisdn = "447700900000", TargetApiKey = "12345" };
+            }
+            else
+            {
+                expectdRequestContent = $"country=GB&msisdn=447700900000&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new NumberTransactionRequest { Country = "GB", Msisdn = "447700900000" };
+            }
+
+            Setup(expectedUri, expectedResponse, expectdRequestContent);
+
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            NumberTransactionResponse response;
+            if (passCreds)
+            {
+                response = await client.NumbersClient.BuyANumberAsync(request, creds);
+            }
+            else
+            {
+                response = await client.NumbersClient.BuyANumberAsync(request);
+            }
+
+            Assert.Equal("200", response.ErrorCode);
+            Assert.Equal("success", response.ErrorCodeLabel);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
         public void TestCancelNumber(bool passCreds, bool kitchenSink)
         {
             var expectedResponse = @"{
@@ -144,6 +242,48 @@ namespace Vonage.Test.Unit
             else
             {
                 response = client.NumbersClient.CancelANumber(request);
+            }
+
+            Assert.Equal("200", response.ErrorCode);
+            Assert.Equal("success", response.ErrorCodeLabel);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public async void TestCancelNumberAsync(bool passCreds, bool kitchenSink)
+        {
+            var expectedResponse = @"{
+              ""error-code"": ""200"",
+              ""error-code-label"": ""success""
+            }";
+            var expectedUri = $"{RestUrl}/number/cancel";
+            string expectdRequestContent = $"country=GB&msisdn=447700900000&api_key={ApiKey}&api_secret={ApiSecret}&";
+            NumberTransactionRequest request;
+
+            if (kitchenSink)
+            {
+                expectdRequestContent = $"country=GB&msisdn=447700900000&target_api_key=12345&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new NumberTransactionRequest { Country = "GB", Msisdn = "447700900000", TargetApiKey = "12345" };
+            }
+            else
+            {
+                expectdRequestContent = $"country=GB&msisdn=447700900000&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new NumberTransactionRequest { Country = "GB", Msisdn = "447700900000" };
+            }
+
+            Setup(expectedUri, expectedResponse, expectdRequestContent);
+
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            NumberTransactionResponse response;
+            if (passCreds)
+            {
+                response = await client.NumbersClient.CancelANumberAsync(request, creds);
+            }
+            else
+            {
+                response = await client.NumbersClient.CancelANumberAsync(request);
             }
 
             Assert.Equal("200", response.ErrorCode);
@@ -198,6 +338,60 @@ namespace Vonage.Test.Unit
             else
             {
                 response = client.NumbersClient.UpdateANumber(request);
+            }
+
+            Assert.Equal("200", response.ErrorCode);
+            Assert.Equal("success", response.ErrorCodeLabel);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public async void TestUpdateNumberAsync(bool passCreds, bool kitchenSink)
+        {
+            var expectedResponse = @"{
+              ""error-code"": ""200"",
+              ""error-code-label"": ""success""
+            }";
+            var expectedUri = $"{RestUrl}/number/update";
+            string expectdRequestContent;
+            UpdateNumberRequest request;
+
+            if (kitchenSink)
+            {
+                expectdRequestContent = $"country=GB&msisdn=447700900000&app_id=aaaaaaaa-bbbb-cccc-dddd-0123456789abc&moHttpUrl={HttpUtility.UrlEncode("https://example.com/webhooks/inbound-sms")}&" +
+                    $"moSmppSysType=inbound&voiceCallbackType=tel&voiceCallbackValue=447700900000&voiceStatusCallback={HttpUtility.UrlEncode("https://example.com/webhooks/status")}&" +
+                    $"api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new UpdateNumberRequest
+                {
+                    Country = "GB",
+                    Msisdn = "447700900000",
+                    AppId = "aaaaaaaa-bbbb-cccc-dddd-0123456789abc",
+                    MoHttpUrl = "https://example.com/webhooks/inbound-sms",
+                    MoSmppSysType = "inbound",
+                    VoiceCallbackType = "tel",
+                    VoiceCallbackValue = "447700900000",
+                    VoiceStatusCallback = "https://example.com/webhooks/status"
+                };
+            }
+            else
+            {
+                expectdRequestContent = $"country=GB&msisdn=447700900000&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new UpdateNumberRequest { Country = "GB", Msisdn = "447700900000" };
+            }
+
+            Setup(expectedUri, expectedResponse, expectdRequestContent);
+
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            NumberTransactionResponse response;
+            if (passCreds)
+            {
+                response = await client.NumbersClient.UpdateANumberAsync(request, creds);
+            }
+            else
+            {
+                response = await client.NumbersClient.UpdateANumberAsync(request);
             }
 
             Assert.Equal("200", response.ErrorCode);

--- a/Vonage.Test.Unit/PricingTests.cs
+++ b/Vonage.Test.Unit/PricingTests.cs
@@ -70,6 +70,65 @@ namespace Vonage.Test.Unit
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        public async void GetPricingForCountryAsync(bool passCreds)
+        {
+            //ARRANGE
+            var expectedUri = $"{RestUrl}/account/get-pricing/outbound/sms?country=CA&api_key={ApiKey}&api_secret={ApiSecret}&";
+            var expectedResponseContent = @"{
+              ""countryCode"": ""CA"",
+              ""countryName"": ""Canada"",
+              ""countryDisplayName"": ""Canada"",
+              ""currency"": ""EUR"",
+              ""defaultPrice"": ""0.00620000"",
+              ""dialingPrefix"": ""1"",
+              ""networks"": [
+                {
+                  ""type"": ""mobile"",
+                  ""price"": ""0.00590000"",
+                  ""currency"": ""EUR"",
+                  ""mcc"": ""302"",
+                  ""mnc"": ""530"",
+                  ""networkCode"": ""302530"",
+                  ""networkName"": ""Keewaytinook Okimakanak""
+                }
+              ]
+            }";
+            Setup(uri: expectedUri, responseContent: expectedResponseContent);
+
+            //ACT
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            Pricing.Country country;
+
+            if (passCreds)
+            {
+                country = await client.PricingClient.RetrievePricingCountryAsync("sms", new Pricing.PricingCountryRequest { Country = "CA" }, creds);
+            }
+            else
+            {
+                country = await client.PricingClient.RetrievePricingCountryAsync("sms", new Pricing.PricingCountryRequest { Country = "CA" });
+            }
+
+            //ASSERT
+
+            Assert.Equal("302530", country.Networks[0].NetworkCode);
+            Assert.Equal("Keewaytinook Okimakanak", country.Networks[0].NetworkName);
+            Assert.Equal("530", country.Networks[0].Mnc);
+            Assert.Equal("302", country.Networks[0].Mcc);
+            Assert.Equal("EUR", country.Networks[0].Currency);
+            Assert.Equal("0.00590000", country.Networks[0].Price);
+            Assert.Equal("mobile", country.Networks[0].Type);
+            Assert.Equal("1", country.DialingPrefix);
+            Assert.Equal("0.00620000", country.DefaultPrice);
+            Assert.Equal("EUR", country.Currency);
+            Assert.Equal("Canada", country.CountryDisplayName);
+            Assert.Equal("Canada", country.CountryName);
+            Assert.Equal("CA", country.CountryCode);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public void GetPricingForPrefix(bool passCreds)
         {
             //ARRANGE
@@ -131,6 +190,67 @@ namespace Vonage.Test.Unit
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        public async void GetPricingForPrefixAsync(bool passCreds)
+        {
+            //ARRANGE
+            var expectedUri = $"{RestUrl}/account/get-prefix-pricing/outbound/sms?prefix=1&api_key={ApiKey}&api_secret={ApiSecret}&";
+            var expectedResponse = @"{
+                  ""count"": ""243"",
+                  ""countries"": [
+                    {
+                      ""countryName"": ""Canada"",
+                      ""countryDisplayName"": ""Canada"",
+                      ""currency"": ""EUR"",
+                      ""defaultPrice"": ""0.00620000"",
+                      ""dialingPrefix"": ""1"",
+                      ""networks"": [
+                        {
+                          ""type"": ""mobile"",
+                          ""price"": ""0.00590000"",
+                          ""currency"": ""EUR"",
+                          ""mcc"": ""302"",
+                          ""mnc"": ""530"",
+                          ""networkCode"": ""302530"",
+                          ""networkName"": ""Keewaytinook Okimakanak""
+                        }
+                      ]
+                    }
+                  ]
+                }";
+            Setup(uri: expectedUri, responseContent: expectedResponse);
+
+            //ACT
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            Pricing.PricingResult pricing;
+            if (passCreds)
+            {
+                pricing = await client.PricingClient.RetrievePrefixPricingAsync("sms", new Pricing.PricingPrefixRequest { Prefix = "1" }, creds);
+            }
+            else
+            {
+                pricing = await client.PricingClient.RetrievePrefixPricingAsync("sms", new Pricing.PricingPrefixRequest { Prefix = "1" });
+            }
+
+            //ASSERT
+            Assert.Equal("302530", pricing.Countries[0].Networks[0].NetworkCode);
+            Assert.Equal("Keewaytinook Okimakanak", pricing.Countries[0].Networks[0].NetworkName);
+            Assert.Equal("530", pricing.Countries[0].Networks[0].Mnc);
+            Assert.Equal("302", pricing.Countries[0].Networks[0].Mcc);
+            Assert.Equal("EUR", pricing.Countries[0].Networks[0].Currency);
+            Assert.Equal("0.00590000", pricing.Countries[0].Networks[0].Price);
+            Assert.Equal("mobile", pricing.Countries[0].Networks[0].Type);
+            Assert.Equal("1", pricing.Countries[0].DialingPrefix);
+            Assert.Equal("0.00620000", pricing.Countries[0].DefaultPrice);
+            Assert.Equal("EUR", pricing.Countries[0].Currency);
+            Assert.Equal("Canada", pricing.Countries[0].CountryDisplayName);
+            Assert.Equal("Canada", pricing.Countries[0].CountryName);
+            Assert.Equal("243", pricing.Count);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public void GetPricingAllCountries(bool passCreds)
         {
             //ARRANGE
@@ -171,6 +291,67 @@ namespace Vonage.Test.Unit
             else
             {
                 pricing = client.PricingClient.RetrievePricingAllCountries("sms");
+            }
+
+            //ASSERT
+            Assert.Equal("302530", pricing.Countries[0].Networks[0].NetworkCode);
+            Assert.Equal("Keewaytinook Okimakanak", pricing.Countries[0].Networks[0].NetworkName);
+            Assert.Equal("530", pricing.Countries[0].Networks[0].Mnc);
+            Assert.Equal("302", pricing.Countries[0].Networks[0].Mcc);
+            Assert.Equal("EUR", pricing.Countries[0].Networks[0].Currency);
+            Assert.Equal("0.00590000", pricing.Countries[0].Networks[0].Price);
+            Assert.Equal("mobile", pricing.Countries[0].Networks[0].Type);
+            Assert.Equal("1", pricing.Countries[0].DialingPrefix);
+            Assert.Equal("0.00620000", pricing.Countries[0].DefaultPrice);
+            Assert.Equal("EUR", pricing.Countries[0].Currency);
+            Assert.Equal("Canada", pricing.Countries[0].CountryDisplayName);
+            Assert.Equal("Canada", pricing.Countries[0].CountryName);
+            Assert.Equal("243", pricing.Count);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async void GetPricingAllCountriesAsync(bool passCreds)
+        {
+            //ARRANGE
+            var expectedUri = $"{RestUrl}/account/get-pricing/outbound/sms?api_key={ApiKey}&api_secret={ApiSecret}&";
+            var expectedResponse = @"{
+                  ""count"": ""243"",
+                  ""countries"": [
+                    {
+                      ""countryName"": ""Canada"",
+                      ""countryDisplayName"": ""Canada"",
+                      ""currency"": ""EUR"",
+                      ""defaultPrice"": ""0.00620000"",
+                      ""dialingPrefix"": ""1"",
+                      ""networks"": [
+                        {
+                          ""type"": ""mobile"",
+                          ""price"": ""0.00590000"",
+                          ""currency"": ""EUR"",
+                          ""mcc"": ""302"",
+                          ""mnc"": ""530"",
+                          ""networkCode"": ""302530"",
+                          ""networkName"": ""Keewaytinook Okimakanak""
+                        }
+                      ]
+                    }
+                  ]
+                }";
+            Setup(uri: expectedUri, responseContent: expectedResponse);
+
+            //ACT
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            Pricing.PricingResult pricing;
+            if (passCreds)
+            {
+                pricing = await client.PricingClient.RetrievePricingAllCountriesAsync("sms", creds);
+            }
+            else
+            {
+                pricing = await client.PricingClient.RetrievePricingAllCountriesAsync("sms");
             }
 
             //ASSERT

--- a/Vonage.Test.Unit/VerifyTest.cs
+++ b/Vonage.Test.Unit/VerifyTest.cs
@@ -271,5 +271,240 @@ namespace Vonage.Test.Unit
             Assert.Equal("abcdef0123456789abcdef0123456789", response.RequestId);
             Assert.Equal("0", response.Status);
         }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public async void RequestVerificationAsync(bool passCreds, bool kitchenSink)
+        {
+            var expectedResponse = @"{
+              ""request_id"": ""abcdef0123456789abcdef0123456789"",
+              ""status"": ""0""
+            }";
+            var expectedUri = $"{ApiUrl}/verify/json";
+
+            string expectedRequestContent;
+            VerifyRequest request = new VerifyRequest { Number = "447700900000", Brand = "Acme Inc" };
+            if (kitchenSink)
+            {
+                expectedRequestContent = $"brand={HttpUtility.UrlEncode("Acme Inc")}&sender_id=ACME&workflow_id=1&number=447700900000&country=GB&code_length=4&lg=en-us&pin_expiry=240&next_event_wait=60&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request.Country = "GB";
+                request.SenderId = "ACME";
+                request.CodeLength = 4;
+                request.Lg = "en-us";
+                request.PinExpiry = 240;
+                request.NextEventWait = 60;
+                request.WorkflowId = VerifyRequest.Workflow.SMS_TTS_TTS;
+            }
+            else
+            {
+                expectedRequestContent = $"brand={HttpUtility.UrlEncode("Acme Inc")}&number=447700900000&api_key={ApiKey}&api_secret={ApiSecret}&";
+            }
+            Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            VerifyResponse response;
+            if (passCreds)
+            {
+                response = await client.VerifyClient.VerifyRequestAsync(request, creds);
+            }
+            else
+            {
+                response = await client.VerifyClient.VerifyRequestAsync(request);
+            }
+
+            Assert.Equal("abcdef0123456789abcdef0123456789", response.RequestId);
+            Assert.Equal("0", response.Status);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public async void TestCheckVerificationAsync(bool passCreds, bool kitchenSink)
+        {
+            var expectedResponse = @"{
+              ""request_id"": ""abcdef0123456789abcdef0123456789"",
+              ""event_id"": ""0A00000012345678"",
+              ""status"": ""0"",
+              ""price"": ""0.10000000"",
+              ""currency"": ""EUR"",
+              ""estimated_price_messages_sent"": ""0.03330000""
+            }";
+            var expectedUri = $"{ApiUrl}/verify/json";
+
+            string expectedRequestContent;
+            VerifyCheckRequest request = new VerifyCheckRequest { Code = "1234", RequestId = "abcdef0123456789abcdef0123456789" };
+            if (kitchenSink)
+            {
+                expectedRequestContent = $"request_id=abcdef0123456789abcdef0123456789&code=1234&ip_address={HttpUtility.UrlEncode("123.0.0.255")}&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request.IpAddress = "123.0.0.255";
+            }
+            else
+            {
+                expectedRequestContent = $"request_id=abcdef0123456789abcdef0123456789&code=1234&api_key={ApiKey}&api_secret={ApiSecret}&";
+            }
+            Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            VerifyCheckResponse response;
+            if (passCreds)
+            {
+                response = await client.VerifyClient.VerifyCheckAsync(request, creds);
+            }
+            else
+            {
+                response = await client.VerifyClient.VerifyCheckAsync(request);
+            }
+            Assert.Equal("0.10000000", response.Price);
+            Assert.Equal("0.03330000", response.EstimatedPriceMessagesSent);
+            Assert.Equal("EUR", response.Currency);
+            Assert.Equal("0A00000012345678", response.EventId);
+            Assert.Equal("abcdef0123456789abcdef0123456789", response.RequestId);
+            Assert.Equal("0", response.Status);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async void TestVerifySearchAsync(bool passCreds)
+        {
+            var expectedResponse = @"{
+              ""request_id"": ""abcdef0123456789abcdef0123456789"",
+              ""account_id"": ""abcdef01"",
+              ""status"": ""IN PROGRESS"",
+              ""number"": ""447700900000"",
+              ""price"": ""0.10000000"",
+              ""currency"": ""EUR"",
+              ""sender_id"": ""mySenderId"",
+              ""date_submitted"": ""2020-01-01 12:00:00"",
+              ""date_finalized"": ""2020-01-01 12:00:00"",
+              ""first_event_date"": ""2020-01-01 12:00:00"",
+              ""last_event_date"": ""2020-01-01 12:00:00"",
+              ""checks"": [
+                {
+                  ""date_received"": ""2020-01-01 12:00:00"",
+                  ""code"": ""987654"",
+                  ""status"": ""abc123"",
+                  ""ip_address"": ""123.0.0.255""
+                }
+              ],
+              ""events"": [
+                {
+                  ""type"": ""abc123"",
+                  ""id"": ""abc123""
+                }
+              ],
+              ""estimated_price_messages_sent"": ""0.03330000""
+            }";
+            var expectedUri = $"{ApiUrl}/verify/search/json?request_id=abcdef0123456789abcdef0123456789&api_key={ApiKey}&api_secret={ApiSecret}&";
+            Setup(expectedUri, expectedResponse);
+            var request = new VerifySearchRequest { RequestId = "abcdef0123456789abcdef0123456789" };
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            VerifySearchResponse response;
+            if (passCreds)
+            {
+                response = await client.VerifyClient.VerifySearchAsync(request, creds);
+            }
+            else
+            {
+                response = await client.VerifyClient.VerifySearchAsync(request);
+            }
+
+            var req = response;
+            Assert.Equal("abcdef0123456789abcdef0123456789", req.RequestId);
+            Assert.Equal("abcdef01", req.AccountId);
+            Assert.Equal("IN PROGRESS", req.Status);
+            Assert.Equal("447700900000", req.Number);
+            Assert.Equal("0.10000000", req.Price);
+            Assert.Equal("EUR", req.Currency);
+            Assert.Equal("mySenderId", req.SenderId);
+            Assert.Equal("2020-01-01 12:00:00", req.DateSubmitted);
+            Assert.Equal("2020-01-01 12:00:00", req.DateFinalized);
+            Assert.Equal("2020-01-01 12:00:00", req.FirstEventDate);
+            Assert.Equal("2020-01-01 12:00:00", req.LastEventDate);
+            Assert.Equal("2020-01-01 12:00:00", req.Checks[0].DateReceived);
+            Assert.Equal("987654", req.Checks[0].Code);
+            Assert.Equal("abc123", req.Checks[0].Status);
+            Assert.Equal("123.0.0.255", req.Checks[0].IpAddress);
+            Assert.Equal("abc123", req.Events[0].Type);
+            Assert.Equal("abc123", req.Events[0].Id);
+            Assert.Equal("0.03330000", req.EstimatedPriceMessagesSent);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async void TestControlVerifyAsync(bool passCreds)
+        {
+            var expectedResponse = @"{
+              ""status"": ""0"",
+              ""command"": ""cancel""
+            }";
+
+            var expectedUri = $"{ApiUrl}/verify/control/json";
+            var requestContent = $"request_id=abcdef0123456789abcdef0123456789&cmd=cancel&api_key={ApiKey}&api_secret={ApiSecret}&";
+            Setup(expectedUri, expectedResponse, requestContent);
+
+            var request = new VerifyControlRequest { Cmd = "cancel", RequestId = "abcdef0123456789abcdef0123456789" };
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            VerifyControlResponse response;
+            if (passCreds)
+            {
+                response = await client.VerifyClient.VerifyControlAsync(request, creds);
+            }
+            else
+            {
+                response = await client.VerifyClient.VerifyControlAsync(request, creds);
+            }
+            Assert.Equal("0", response.Status);
+            Assert.Equal("cancel", response.Command);
+        }
+        
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public async void Psd2VerificationAsync(bool passCreds, bool kitchenSink)
+        {
+            var expectedResponse = @"{
+              ""request_id"": ""abcdef0123456789abcdef0123456789"",
+              ""status"": ""0""
+            }";
+            var expectedUri = $"{ApiUrl}/verify/psd2/json";
+
+            string expectedRequestContent;
+            Psd2Request request = new Psd2Request { Number = "447700900000", Payee = "Acme Inc", Amount = 4.8 };
+            if (kitchenSink)
+            {
+                expectedRequestContent = $"payee={HttpUtility.UrlEncode("Acme Inc")}&amount=4.8&workflow_id=1&number=447700900000&country=GB&code_length=4&lg=en-us&pin_expiry=240&next_event_wait=60&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request.Country = "GB";
+                request.CodeLength = 4;
+                request.Lg = "en-us";
+                request.PinExpiry = 240;
+                request.NextEventWait = 60;
+                request.WorkflowId = Psd2Request.Workflow.SMS_TTS_TTS;
+            }
+            else
+            {
+                expectedRequestContent = $"payee={HttpUtility.UrlEncode("Acme Inc")}&amount=4.8&number=447700900000&api_key={ApiKey}&api_secret={ApiSecret}&";
+            }
+
+            Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            VerifyResponse response;
+            if (passCreds)
+            {
+                response = client.VerifyClient.VerifyRequestWithPSD2(request, creds);
+            }
+            else
+            {
+                response = client.VerifyClient.VerifyRequestWithPSD2(request);
+            }
+
+            Assert.Equal("abcdef0123456789abcdef0123456789", response.RequestId);
+            Assert.Equal("0", response.Status);
+        }
     }
 }

--- a/Vonage/Accounts/AccountClient.cs
+++ b/Vonage/Accounts/AccountClient.cs
@@ -83,37 +83,71 @@ namespace Vonage.Accounts
 
         public Balance GetAccountBalance(Credentials creds = null)
         {
-            return GetAccountBalanceAsync(creds).GetAwaiter().GetResult();
+            return ApiRequest.DoGetRequestWithQueryParameters<Balance>(
+                ApiRequest.GetBaseUriFor(typeof(AccountClient),
+                "/account/get-balance"),
+                ApiRequest.AuthType.Query,
+                credentials: creds ?? Credentials);
         }
 
         public TopUpResult TopUpAccountBalance(TopUpRequest request, Credentials creds = null)
         {
-            return TopUpAccountBalanceAsync(request, creds).GetAwaiter().GetResult();
+            return ApiRequest.DoGetRequestWithQueryParameters<TopUpResult>(
+                ApiRequest.GetBaseUriFor(typeof(AccountClient), "/account/top-up"),
+                ApiRequest.AuthType.Query,
+                request,
+                credentials: creds ?? Credentials
+            );
         }
 
         public AccountSettingsResult ChangeAccountSettings(AccountSettingsRequest request, Credentials creds = null)
         {
-            return ChangeAccountSettingsAsync(request, creds).GetAwaiter().GetResult();
+            return ApiRequest.DoPostRequestUrlContentFromObject<AccountSettingsResult>
+            (
+                ApiRequest.GetBaseUriFor(typeof(AccountClient), "/account/settings"),
+                request,
+                creds ?? Credentials
+            );
         }
 
         public SecretsRequestResult RetrieveApiSecrets(string apiKey = null, Credentials creds = null)
         {
-            return RetrieveApiSecretsAsync(apiKey, creds).GetAwaiter().GetResult();
+            return ApiRequest.DoGetRequestWithQueryParameters<SecretsRequestResult>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, $"/accounts/{apiKey}/secrets"),
+                ApiRequest.AuthType.Basic,
+                credentials: creds ?? Credentials
+            );
         }
 
         public Secret CreateApiSecret(CreateSecretRequest request, string apiKey = null, Credentials creds = null)
         {
-            return CreateApiSecretAsync(request, apiKey, creds).GetAwaiter().GetResult();
+            return ApiRequest.DoRequestWithJsonContent<Secret>(
+                "POST",
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, $"/accounts/{apiKey}/secrets"),
+                request,
+                ApiRequest.AuthType.Basic,
+                creds: creds ?? Credentials
+            );
         }
 
         public Secret RetrieveApiSecret(string secretId, string apiKey = null, Credentials creds = null)
         {
-            return RetrieveApiSecretAsync(secretId, apiKey, creds).GetAwaiter().GetResult();
+            return ApiRequest.DoGetRequestWithQueryParameters<Secret>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, $"/accounts/{apiKey}/secrets/{secretId}"),
+                ApiRequest.AuthType.Basic,
+                credentials: creds ?? Credentials
+            );
         }
 
         public bool RevokeApiSecret(string secretId, string apiKey = null, Credentials creds = null)
         {
-            return RevokeApiSecretAsync(secretId, apiKey, creds).GetAwaiter().GetResult();
+            ApiRequest.DoDeleteRequestWithUrlContent(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, $"/accounts/{apiKey}/secrets/{secretId}"),
+                null,
+                ApiRequest.AuthType.Basic,
+                creds ?? Credentials
+            );
+            return true;
         }
     }
 }

--- a/Vonage/Applications/ApplicationClient.cs
+++ b/Vonage/Applications/ApplicationClient.cs
@@ -64,27 +64,54 @@ namespace Vonage.Applications
 
         public Application CreateApplicaiton(CreateApplicationRequest request, Credentials creds = null)
         {
-            return CreateApplicaitonAsync(request, creds).GetAwaiter().GetResult();
+            return ApiRequest.DoRequestWithJsonContent<Application>(
+                "POST",
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, "/v2/applications"),
+                request,
+                ApiRequest.AuthType.Basic,
+                creds ?? Credentials
+            );
         }
 
         public ApplicationPage ListApplications(ListApplicationsRequest request, Credentials creds = null)
         {
-            return ListApplicationsAsync(request, creds).GetAwaiter().GetResult();
+            return ApiRequest.DoGetRequestWithQueryParameters<ApplicationPage>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, "/v2/applications"),
+                ApiRequest.AuthType.Basic,
+                request,
+                creds ?? Credentials
+            );
         }
 
         public Application GetApplication(string id, Credentials creds = null)
         {
-            return GetApplicationAsync(id, creds).GetAwaiter().GetResult();
+            return ApiRequest.DoGetRequestWithQueryParameters<Application>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, $"/v2/applications/{id}"),
+                ApiRequest.AuthType.Basic,
+                credentials: creds ?? Credentials
+            );
         }
 
         public Application UpdateApplication(string id, CreateApplicationRequest request, Credentials creds = null)
         {
-            return UpdateApplicationAsync(id, request, creds).GetAwaiter().GetResult();
+            return ApiRequest.DoRequestWithJsonContent<Application>(
+                "PUT",
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, $"/v2/applications/{id}"),
+                request,
+                ApiRequest.AuthType.Basic,
+                creds ?? Credentials
+            );
         }
 
         public bool DeleteApplication(string id, Credentials creds = null)
         {
-            return DeleteApplicationAsync(id, creds).GetAwaiter().GetResult();
+            ApiRequest.DoDeleteRequestWithUrlContent(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, $"/v2/applications/{id}"),
+                null,
+                ApiRequest.AuthType.Basic,
+                creds ?? Credentials
+            );
+            return true;
         }
     }
 }

--- a/Vonage/Conversions/ConversionClient.cs
+++ b/Vonage/Conversions/ConversionClient.cs
@@ -35,12 +35,24 @@ namespace Vonage.Conversions
 
         public bool SmsConversion(ConversionRequest request, Credentials creds = null)
         {
-            return SmsConversionAsync(request, creds).GetAwaiter().GetResult();
+            ApiRequest.DoPostRequestUrlContentFromObject<object>
+            (
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, "/conversions/sms"),
+                request,
+                creds ?? Credentials
+            );
+            return true;
         }
 
         public bool VoiceConversion(ConversionRequest request, Credentials creds = null)
         {
-            return VoiceConversionAsync(request, creds).GetAwaiter().GetResult();
+            ApiRequest.DoPostRequestUrlContentFromObject<object>
+            (
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, "/conversions/voice"),
+                request,
+                creds ?? Credentials
+            );
+            return true;
         }
     }
 }

--- a/Vonage/Messaging/SmsClient.cs
+++ b/Vonage/Messaging/SmsClient.cs
@@ -33,7 +33,14 @@ namespace Vonage.Messaging
 
         public SendSmsResponse SendAnSms(SendSmsRequest request, Credentials creds = null)
         {
-            return SendAnSmsAsync(request, creds).GetAwaiter().GetResult();
+            var result = ApiRequest.DoPostRequestUrlContentFromObject<SendSmsResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/sms/json"),
+                request,
+                creds ?? Credentials
+            );
+
+            ValidSmsResponse(result);
+            return result;
         }
 
         public Task<SendSmsResponse> SendAnSmsAsync(string from, string to, string text, SmsType type = SmsType.text, Credentials creds = null)

--- a/Vonage/NumberInsights/NumberInsightClient.cs
+++ b/Vonage/NumberInsights/NumberInsightClient.cs
@@ -77,22 +77,50 @@ namespace Vonage.NumberInsights
 
         public BasicInsightResponse GetNumberInsightBasic(BasicNumberInsightRequest request, Credentials creds = null)
         {
-            return GetNumberInsightBasicAsync(request, creds).GetAwaiter().GetResult();
+            var response = ApiRequest.DoGetRequestWithQueryParameters<BasicInsightResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, "/ni/basic/json"),
+                ApiRequest.AuthType.Query,
+                request,
+                creds ?? Credentials
+            );
+            ValidateNumberInsightResponse(response);
+            return response;
         }
 
         public StandardInsightResponse GetNumberInsightStandard(StandardNumberInsightRequest request, Credentials creds = null)
         {
-            return GetNumberInsightStandardAsync(request, creds).GetAwaiter().GetResult();
+            var response = ApiRequest.DoGetRequestWithQueryParameters<StandardInsightResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, "/ni/standard/json"),
+                ApiRequest.AuthType.Query,
+                request,
+                creds ?? Credentials
+            );
+            ValidateNumberInsightResponse(response);
+            return response;
         }
 
         public AdvancedInsightsResponse GetNumberInsightAdvanced(AdvancedNumberInsightRequest request, Credentials creds = null)
         {
-            return GetNumberInsightAdvancedAsync(request, creds).GetAwaiter().GetResult();
+            var response = ApiRequest.DoGetRequestWithQueryParameters<AdvancedInsightsResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, "/ni/advanced/json"),
+                ApiRequest.AuthType.Query,
+                request,
+                creds ?? Credentials
+            );
+            ValidateNumberInsightResponse(response);
+            return response;
         }
 
         public AdvancedInsightsAsyncResponse GetNumberInsightAsync(AdvancedNumberInsightAsynchronousRequest request, Credentials creds = null)
         {
-            return GetNumberInsightAsyncAsync(request, creds).GetAwaiter().GetResult();
+            var response = ApiRequest.DoGetRequestWithQueryParameters<AdvancedInsightsAsyncResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, "/ni/advanced/async/json"),
+                ApiRequest.AuthType.Query,
+                request,
+                creds ?? Credentials
+            );
+            ValidateNumberInsightResponse(response);
+            return response;
         }
     }
 }

--- a/Vonage/Numbers/NumbersClient.cs
+++ b/Vonage/Numbers/NumbersClient.cs
@@ -77,27 +77,55 @@ namespace Vonage.Numbers
 
         public NumbersSearchResponse GetOwnedNumbers(NumberSearchRequest request, Credentials creds = null)
         {
-            return GetOwnedNumbersAsync(request, creds).GetAwaiter().GetResult();
+            return ApiRequest.DoGetRequestWithQueryParameters<NumbersSearchResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/account/numbers"),
+                ApiRequest.AuthType.Query,
+                request,
+                creds ?? Credentials
+                );
         }
 
         public NumbersSearchResponse GetAvailableNumbers(NumberSearchRequest request, Credentials creds = null)
         {
-            return GetAvailableNumbersAsync(request, creds).GetAwaiter().GetResult();
+            return ApiRequest.DoGetRequestWithQueryParameters<NumbersSearchResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/number/search"),
+                ApiRequest.AuthType.Query,
+                request,
+                creds ?? Credentials
+            );
         }
 
         public NumberTransactionResponse BuyANumber(NumberTransactionRequest request, Credentials creds = null)
         {
-            return BuyANumberAsync(request, creds).GetAwaiter().GetResult();
+            var response = ApiRequest.DoPostRequestUrlContentFromObject<NumberTransactionResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/number/buy"),
+                request,
+                creds ?? Credentials
+            );
+            ValidateNumbersResponse(response);
+            return response;
         }
 
         public NumberTransactionResponse CancelANumber(NumberTransactionRequest request, Credentials creds = null)
         {
-            return CancelANumberAsync(request, creds).GetAwaiter().GetResult();
+            var response = ApiRequest.DoPostRequestUrlContentFromObject<NumberTransactionResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/number/cancel"),
+                request,
+                creds ?? Credentials
+            );
+            ValidateNumbersResponse(response);
+            return response;
         }
 
         public NumberTransactionResponse UpdateANumber(UpdateNumberRequest request, Credentials creds = null)
         {
-            return UpdateANumberAsync(request, creds).GetAwaiter().GetResult();
+            var response = ApiRequest.DoPostRequestUrlContentFromObject<NumberTransactionResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/number/update"),
+                request,
+                creds ?? Credentials
+            );
+            ValidateNumbersResponse(response);
+            return response;
         }
     }
 }

--- a/Vonage/Pricing/PricingClient.cs
+++ b/Vonage/Pricing/PricingClient.cs
@@ -46,17 +46,34 @@ namespace Vonage.Pricing
 
         public Country RetrievePricingCountry(string type, PricingCountryRequest request, Credentials creds = null)
         {
-            return RetrievePricingCountryAsync(type, request, creds).GetAwaiter().GetResult();
+            return ApiRequest.DoGetRequestWithQueryParameters<Country>
+            (
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, $"/account/get-pricing/outbound/{type}"),
+                ApiRequest.AuthType.Query,
+                request,
+                creds ?? Credentials
+            );
         }
 
         public PricingResult RetrievePricingAllCountries(string type, Credentials creds = null)
         {
-            return RetrievePricingAllCountriesAsync(type, creds).GetAwaiter().GetResult();
+            return ApiRequest.DoGetRequestWithQueryParameters<PricingResult>
+            (
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, $"/account/get-pricing/outbound/{type}"),
+                ApiRequest.AuthType.Query,
+                credentials: creds ?? Credentials
+            );
         }
 
         public PricingResult RetrievePrefixPricing(string type, PricingPrefixRequest request, Credentials creds = null)
         {
-            return RetrievePrefixPricingAsync(type, request, creds).GetAwaiter().GetResult();
+            return ApiRequest.DoGetRequestWithQueryParameters<PricingResult>
+            (
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, $"/account/get-prefix-pricing/outbound/{type}"),
+                ApiRequest.AuthType.Query,
+                request,
+                creds ?? Credentials
+            );
         }
     }
 }

--- a/Vonage/Redaction/RedactClient.cs
+++ b/Vonage/Redaction/RedactClient.cs
@@ -28,7 +28,15 @@ namespace Vonage.Redaction
 
         public bool Redact(RedactRequest request, Credentials creds = null)
         {
-            return RedactAsync(request, creds).GetAwaiter().GetResult();
+            ApiRequest.DoRequestWithJsonContent<object>
+            (
+                "POST",
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, "/v1/redact/transaction"),
+                request,
+                ApiRequest.AuthType.Basic,
+                creds ?? Credentials
+            );
+            return true;
         }
     }
 }

--- a/Vonage/ShortCodes/ShortCodesClient.cs
+++ b/Vonage/ShortCodes/ShortCodesClient.cs
@@ -49,22 +49,38 @@ namespace Vonage.ShortCodes
 
         public OptInSearchResponse QueryOptIns(OptInQueryRequest request, Credentials creds = null)
         {
-            return QueryOptInsAsync(request, creds).GetAwaiter().GetResult();
+            return ApiRequest.DoGetRequestWithQueryParameters<OptInSearchResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/sc/us/alert/opt-in/query/json"),
+                ApiRequest.AuthType.Query,
+                request,
+                creds ?? Credentials);
         }
 
         public OptInRecord ManageOptIn(OptInManageRequest request, Credentials creds = null)
         {
-            return ManageOptInAsync(request, creds).GetAwaiter().GetResult();
+            return ApiRequest.DoGetRequestWithQueryParameters<OptInRecord>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/sc/us/alert/opt-in/manage/json"),
+                ApiRequest.AuthType.Query,
+                request,
+                creds ?? Credentials);
         }
 
         public AlertResponse SendAlert(AlertRequest request, Credentials creds = null)
         {
-            return SendAlertAsync(request, creds).GetAwaiter().GetResult();
+            return ApiRequest.DoGetRequestWithQueryParameters<AlertResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/sc/us/alert/json"),
+                ApiRequest.AuthType.Query,
+                request,
+                creds ?? Credentials);
         }
 
         public TwoFactorAuthResponse SendTwoFactorAuth(TwoFactorAuthRequest request, Credentials creds = null)
         {
-            return SendTwoFactorAuthAsync(request, creds).GetAwaiter().GetResult();
+            return ApiRequest.DoGetRequestWithQueryParameters<TwoFactorAuthResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/sc/us/2fa/json"),
+                ApiRequest.AuthType.Query,
+                request,
+                creds ?? Credentials);
         }
     }
 }

--- a/Vonage/Verify/VerifyClient.cs
+++ b/Vonage/Verify/VerifyClient.cs
@@ -67,27 +67,56 @@ namespace Vonage.Verify
 
         public VerifyResponse VerifyRequest(VerifyRequest request, Credentials creds = null)
         {
-            return VerifyRequestAsync(request, creds).GetAwaiter().GetResult();
+            var response = ApiRequest.DoPostRequestUrlContentFromObject<VerifyResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, "/verify/json"),
+                request,
+                creds ?? Credentials
+            );
+            ValidateVerifyResponse(response);
+            return response;
         }
 
         public VerifyCheckResponse VerifyCheck(VerifyCheckRequest request, Credentials creds = null)
         {
-            return VerifyCheckAsync(request, creds).GetAwaiter().GetResult();
+            var response = ApiRequest.DoPostRequestUrlContentFromObject<VerifyCheckResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, "/verify/check/json"),
+                request,
+                creds ?? Credentials
+            );
+            ValidateVerifyResponse(response);
+            return response;
         }
 
         public VerifySearchResponse VerifySearch(VerifySearchRequest request, Credentials creds = null)
         {
-            return VerifySearchAsync(request, creds).GetAwaiter().GetResult();
+            return ApiRequest.DoGetRequestWithQueryParameters<VerifySearchResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, "/verify/search/json"),
+                ApiRequest.AuthType.Query,
+                request,
+                creds ?? Credentials
+            );
         }
 
         public VerifyControlResponse VerifyControl(VerifyControlRequest request, Credentials creds = null)
         {
-            return VerifyControlAsync(request, creds).GetAwaiter().GetResult();
+            var response = ApiRequest.DoPostRequestUrlContentFromObject<VerifyControlResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, "/verify/control/json"),
+                request,
+                creds ?? Credentials
+            );
+            ValidateVerifyResponse(response);
+            return response;
         }
 
         public VerifyResponse VerifyRequestWithPSD2(Psd2Request request, Credentials creds = null)
         {
-            return VerifyRequestWithPSD2Async(request, creds).GetAwaiter().GetResult();
+            var response = ApiRequest.DoPostRequestUrlContentFromObject<VerifyResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, "/verify/psd2/json"),
+                request,
+                creds ?? Credentials
+            );
+            ValidateVerifyResponse(response);
+            return response;
         }
 
         public void ValidateVerifyResponse(VerifyResponseBase response)


### PR DESCRIPTION
When the Async pattern was added to the .NET SDK we did so initially by adding a whole set of asynchronous methods and then pointing the synchronous methods at them. To preserve the call-stack when exceptions are raised we used the `GetAwaitor().GetResult()` pattern - unfortunately, that pattern exposes a potential deadlock condition when using single-threaded UI frameworks (e.g. Blazor Server). Consequentially I had to disentangle the Async and synchronous methods - and add new tests for the asynchronous methods to maintain coverage.