### PR TITLE
setting Channels parameter to nullable

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -17,6 +17,8 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '3.1.401'
+    - name: Clean
+      run: dotnet clean Vonage.sln --configuration Release && dotnet nuget locals all --clear
     - name: Install dependencies
       run: |
         dotnet restore

--- a/Nexmo.Api.Test.Unit/NccoTests.cs
+++ b/Nexmo.Api.Test.Unit/NccoTests.cs
@@ -34,6 +34,15 @@ namespace Nexmo.Api.Test.Unit
         }
 
         [Fact]
+        public void TestRecordMinimalist()
+        {
+            var expectedJson = @"[{""action"":""record""}]";
+            var recordAction = new RecordAction();
+            var ncco = new Ncco(recordAction);
+            Assert.Equal(expectedJson, ncco.ToString());
+        }
+
+        [Fact]
         public void TestConversation()
         {
             var expectedJson = @"[{""name"":""nexmo-conference-standard"",""musicOnHoldUrl"":[""https://example.com/music.mp3""],""startOnEnter"":""true"",""endOnExit"":""false"",""record"":""true"",""canSpeak"":[""6a4d6af0-55a6-4667-be90-8614e4c8e83c""],""canHear"":[""6a4d6af0-55a6-4667-be90-8614e4c8e83c""],""action"":""conversation""}]";

--- a/Vonage.Test.Unit/NccoTests.cs
+++ b/Vonage.Test.Unit/NccoTests.cs
@@ -29,6 +29,15 @@ namespace Vonage.Test.Unit
         }
 
         [Fact]
+        public void TestRecordMinimalist()
+        {
+            var expectedJson = @"[{""action"":""record""}]";
+            var recordAction = new RecordAction();
+            var ncco = new Ncco(recordAction);
+            Assert.Equal(expectedJson, ncco.ToString());
+        }
+
+        [Fact]
         public void TestConversation()
         {
             var expectedJson = @"[{""name"":""vonage-conference-standard"",""musicOnHoldUrl"":[""https://example.com/music.mp3""],""startOnEnter"":""true"",""endOnExit"":""false"",""record"":""true"",""canSpeak"":[""6a4d6af0-55a6-4667-be90-8614e4c8e83c""],""canHear"":[""6a4d6af0-55a6-4667-be90-8614e4c8e83c""],""action"":""conversation""}]";

--- a/Vonage/LegacyNexmoLibrary/Voice/Nccos/RecordAction.cs
+++ b/Vonage/LegacyNexmoLibrary/Voice/Nccos/RecordAction.cs
@@ -35,7 +35,7 @@ namespace Nexmo.Api.Voice.Nccos
         /// will be added to the last channel in file. split conversation must also be enabled
         /// </summary>
         [JsonProperty("channels")]
-        public uint Channels { get; set; }
+        public uint? Channels { get; set; }
 
         /// <summary>
         /// Stop recording after n seconds of silence. 

--- a/Vonage/Voice/Nccos/RecordAction.cs
+++ b/Vonage/Voice/Nccos/RecordAction.cs
@@ -33,7 +33,7 @@ namespace Vonage.Voice.Nccos
         /// will be added to the last channel in file. split conversation must also be enabled
         /// </summary>
         [JsonProperty("channels")]
-        public uint Channels { get; set; }
+        public uint? Channels { get; set; }
 
         /// <summary>
         /// Stop recording after n seconds of silence. 


### PR DESCRIPTION
`RecordAction` does not serialize correctly because the `Channels` parameter is not nullable, the default behavior is thus to serialize it to 0, which is not a valid setting. setting `Channels` parameter to nullable to have the serializer ignore it during serialization. Also adding tests to test a minimalist version of the `RecordAction`