### PR TITLE
moving readme/GHA to 5.x

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -2,9 +2,9 @@ name: .NET Core
 
 on:
   push:
-    branches: [ master]
+    branches: [ 5.x ]
   pull_request:
-    branches: [ master ]
+    branches: [ 5.x ]
 
 jobs:
   build:

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -13,7 +13,7 @@ jobs:
         uses: nexmo/github-actions/nuget-release@main
         env:
           PROJECT_FILE : Vonage/Vonage.csproj          
-          BRANCH: master
+          BRANCH: 5.x
           ORGANIZATION: Vonage
           REPO: vonage-dotnet-sdk
           TAG: ${{ github.event.release.tag_name }}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Vonage Client Library for .NET
 
 [![](http://img.shields.io/nuget/v/Vonage.svg?style=flat-square)](https://www.nuget.org/packages/Vonage/)
 [![Build Status](https://github.com/Vonage/vonage-dotnet/workflows/.NET%20Core/badge.svg)](https://github.com/Nexmo/nexmo-dotnet/actions?query=workflow%3A%22.NET+Core%22)
-[![codecov](https://codecov.io/gh/Vonage/vonage-dotnet-sdk/branch/master/graph/badge.svg)](https://codecov.io/gh/Vonage/vonage-dotnet-sdk)
+[![codecov](https://codecov.io/gh/Vonage/vonage-dotnet-sdk/branch/5.x/graph/badge.svg)](https://codecov.io/gh/Vonage/vonage-dotnet-sdk)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 
 <img src="https://developer.nexmo.com/assets/images/Vonage_Nexmo.svg" height="48px" alt="Nexmo is now known as Vonage" />


### PR DESCRIPTION
Moving the GHA and readme to 5.x (codecov will need to catchup with the badge)