### PR TITLE
Support for NI Null values

### DIFF
--- a/Vonage.Test.Unit/NumberInsightsTests.cs
+++ b/Vonage.Test.Unit/NumberInsightsTests.cs
@@ -238,6 +238,218 @@ namespace Vonage.Test.Unit
         [Theory]
         [InlineData(true, true)]
         [InlineData(false, false)]
+        public void TestStandardNIRequestWithoutRoaming(bool passCreds, bool kitchenSink)
+        {
+            //ARRANGE
+            var expectedResponse = @"{
+              ""status"": 0,
+              ""status_message"": ""Success"",
+              ""request_id"": ""aaaaaaaa-bbbb-cccc-dddd-0123456789ab"",
+              ""international_format_number"": ""447700900000"",
+              ""national_format_number"": ""07700 900000"",
+              ""country_code"": ""GB"",
+              ""country_code_iso3"": ""GBR"",
+              ""country_name"": ""United Kingdom"",
+              ""country_prefix"": ""44"",
+              ""request_price"": ""0.04000000"",
+              ""refund_price"": ""0.01500000"",
+              ""remaining_balance"": ""1.23456789"",
+              ""current_carrier"": {
+                ""network_code"": ""12345"",
+                ""name"": ""Acme Inc"",
+                ""country"": ""GB"",
+                ""network_type"": ""mobile""
+              },
+              ""original_carrier"": {
+                ""network_code"": ""12345"",
+                ""name"": ""Acme Inc"",
+                ""country"": ""GB"",
+                ""network_type"": ""mobile""
+              },
+              ""ported"": ""not_ported"",
+              ""roaming"": ""unknown"",
+              ""caller_identity"": {
+                            ""caller_type"": ""consumer"",
+                ""caller_name"": ""John Smith"",
+                ""first_name"": ""John"",
+                ""last_name"": ""Smith""
+              },
+              ""caller_name"": ""John Smith"",
+              ""last_name"": ""Smith"",
+              ""first_name"": ""John"",
+              ""caller_type"": ""consumer""
+            }";
+            var expectedUri = $"{ApiUrl}/ni/standard/json";
+            StandardNumberInsightRequest request;
+            if (kitchenSink)
+            {
+                expectedUri+= $"?cnam=true&number=15555551212&country=GB&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new StandardNumberInsightRequest { Cnam = true, Country = "GB", Number = "15555551212" };
+            }
+            else
+            {
+                expectedUri += $"?number=15555551212&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new StandardNumberInsightRequest
+                {
+                    Number = "15555551212"
+                };
+            }
+
+            Setup(expectedUri, expectedResponse);
+
+            //ACT
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            StandardInsightResponse response;
+            if (passCreds)
+            {
+                response = client.NumberInsightClient.GetNumberInsightStandard(request, creds);
+            }
+            else
+            {
+                response = client.NumberInsightClient.GetNumberInsightStandard(request);
+            }
+            Assert.Equal("John", response.FirstName);
+            Assert.Equal(CallerType.consumer, response.CallerType);
+            Assert.Equal("Smith", response.LastName);
+            Assert.Equal("John Smith", response.CallerName);
+            Assert.Equal("Smith", response.CallerIdentity.LastName);
+            Assert.Equal("John", response.CallerIdentity.FirstName);
+            Assert.Equal("John Smith", response.CallerIdentity.CallerName);
+            Assert.Equal(CallerType.consumer, response.CallerIdentity.CallerType);
+            Assert.Equal(RoamingStatus.unknown, response.Roaming.Status);
+            Assert.Equal(PortedStatus.not_ported, response.Ported);
+            Assert.Equal("12345", response.OriginalCarrier.NetworkCode);
+            Assert.Equal("Acme Inc", response.OriginalCarrier.Name);
+            Assert.Equal("GB", response.OriginalCarrier.Country);
+            Assert.Equal("mobile", response.OriginalCarrier.NetworkType);
+            Assert.Equal(0, response.Status);
+            Assert.Equal("Success", response.StatusMessage);
+            Assert.Equal("aaaaaaaa-bbbb-cccc-dddd-0123456789ab", response.RequestId);
+            Assert.Equal("447700900000", response.InternationalFormatNumber);
+            Assert.Equal("07700 900000", response.NationalFormatNumber);
+            Assert.Equal("GB", response.CountryCode);
+            Assert.Equal("GBR", response.CountryCodeIso3);
+            Assert.Equal("United Kingdom", response.CountryName);
+            Assert.Equal("44", response.CountryPrefix);
+            Assert.Equal("0.04000000", response.RequestPrice);
+            Assert.Equal("0.01500000", response.RefundPrice);
+            Assert.Equal("1.23456789", response.RemainingBalance);
+            Assert.Equal("12345", response.CurrentCarrier.NetworkCode);
+            Assert.Equal("Acme Inc", response.CurrentCarrier.Name);
+            Assert.Equal("GB", response.CurrentCarrier.Country);
+            Assert.Equal("mobile", response.CurrentCarrier.NetworkType);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void TestStandardNIRequestWithNullCarrier(bool passCreds, bool kitchenSink)
+        {
+            //ARRANGE
+            var expectedResponse = @"{
+              ""status"": 0,
+              ""status_message"": ""Success"",
+              ""request_id"": ""aaaaaaaa-bbbb-cccc-dddd-0123456789ab"",
+              ""international_format_number"": ""447700900000"",
+              ""national_format_number"": ""07700 900000"",
+              ""country_code"": ""GB"",
+              ""country_code_iso3"": ""GBR"",
+              ""country_name"": ""United Kingdom"",
+              ""country_prefix"": ""44"",
+              ""request_price"": ""0.04000000"",
+              ""refund_price"": ""0.01500000"",
+              ""remaining_balance"": ""1.23456789"",
+              ""current_carrier"": {
+                ""network_code"": null,
+                ""name"": null,
+                ""country"": null,
+                ""network_type"": null
+              },
+              ""original_carrier"": {
+                ""network_code"": ""12345"",
+                ""name"": ""Acme Inc"",
+                ""country"": ""GB"",
+                ""network_type"": ""mobile""
+              },
+              ""ported"": ""not_ported"",
+              ""roaming"": ""unknown"",
+              ""caller_identity"": {
+                            ""caller_type"": ""consumer"",
+                ""caller_name"": ""John Smith"",
+                ""first_name"": ""John"",
+                ""last_name"": ""Smith""
+              },
+              ""caller_name"": ""John Smith"",
+              ""last_name"": ""Smith"",
+              ""first_name"": ""John"",
+              ""caller_type"": ""consumer""
+            }";
+            var expectedUri = $"{ApiUrl}/ni/standard/json";
+            StandardNumberInsightRequest request;
+            if (kitchenSink)
+            {
+                expectedUri+= $"?cnam=true&number=15555551212&country=GB&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new StandardNumberInsightRequest { Cnam = true, Country = "GB", Number = "15555551212" };
+            }
+            else
+            {
+                expectedUri += $"?number=15555551212&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new StandardNumberInsightRequest
+                {
+                    Number = "15555551212"
+                };
+            }
+
+            Setup(expectedUri, expectedResponse);
+
+            //ACT
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            StandardInsightResponse response;
+            if (passCreds)
+            {
+                response = client.NumberInsightClient.GetNumberInsightStandard(request, creds);
+            }
+            else
+            {
+                response = client.NumberInsightClient.GetNumberInsightStandard(request);
+            }
+            Assert.Equal("John", response.FirstName);
+            Assert.Equal(CallerType.consumer, response.CallerType);
+            Assert.Equal("Smith", response.LastName);
+            Assert.Equal("John Smith", response.CallerName);
+            Assert.Equal("Smith", response.CallerIdentity.LastName);
+            Assert.Equal("John", response.CallerIdentity.FirstName);
+            Assert.Equal("John Smith", response.CallerIdentity.CallerName);
+            Assert.Equal(CallerType.consumer, response.CallerIdentity.CallerType);
+            Assert.Equal(RoamingStatus.unknown, response.Roaming.Status);
+            Assert.Equal(PortedStatus.not_ported, response.Ported);
+            Assert.Equal("12345", response.OriginalCarrier.NetworkCode);
+            Assert.Equal("Acme Inc", response.OriginalCarrier.Name);
+            Assert.Equal("GB", response.OriginalCarrier.Country);
+            Assert.Equal("mobile", response.OriginalCarrier.NetworkType);
+            Assert.Equal(0, response.Status);
+            Assert.Equal("Success", response.StatusMessage);
+            Assert.Equal("aaaaaaaa-bbbb-cccc-dddd-0123456789ab", response.RequestId);
+            Assert.Equal("447700900000", response.InternationalFormatNumber);
+            Assert.Equal("07700 900000", response.NationalFormatNumber);
+            Assert.Equal("GB", response.CountryCode);
+            Assert.Equal("GBR", response.CountryCodeIso3);
+            Assert.Equal("United Kingdom", response.CountryName);
+            Assert.Equal("44", response.CountryPrefix);
+            Assert.Equal("0.04000000", response.RequestPrice);
+            Assert.Equal("0.01500000", response.RefundPrice);
+            Assert.Equal("1.23456789", response.RemainingBalance);
+            Assert.Null(response.CurrentCarrier.NetworkCode);
+            Assert.Null(response.CurrentCarrier.Name);
+            Assert.Null(response.CurrentCarrier.Country);
+            Assert.Null(response.CurrentCarrier.NetworkType);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
         public async void TestStandardNIRequestAsync(bool passCreds, bool kitchenSink)
         {
             //ARRANGE
@@ -575,6 +787,122 @@ namespace Vonage.Test.Unit
             Assert.Equal("US", response.Roaming.RoamingCountryCode);
             Assert.Equal(RoamingStatus.roaming, response.Roaming.Status);
             Assert.Equal(PortedStatus.not_ported, response.Ported);
+            Assert.Equal("12345", response.OriginalCarrier.NetworkCode);
+            Assert.Equal("Acme Inc", response.OriginalCarrier.Name);
+            Assert.Equal("GB", response.OriginalCarrier.Country);
+            Assert.Equal("mobile", response.OriginalCarrier.NetworkType);
+            Assert.Equal(0, response.Status);
+            Assert.Equal("Success", response.StatusMessage);
+            Assert.Equal("aaaaaaaa-bbbb-cccc-dddd-0123456789ab", response.RequestId);
+            Assert.Equal("447700900000", response.InternationalFormatNumber);
+            Assert.Equal("07700 900000", response.NationalFormatNumber);
+            Assert.Equal("GB", response.CountryCode);
+            Assert.Equal("GBR", response.CountryCodeIso3);
+            Assert.Equal("United Kingdom", response.CountryName);
+            Assert.Equal("44", response.CountryPrefix);
+            Assert.Equal("0.04000000", response.RequestPrice);
+            Assert.Equal("0.01500000", response.RefundPrice);
+            Assert.Equal("1.23456789", response.RemainingBalance);
+            Assert.Equal("12345", response.CurrentCarrier.NetworkCode);
+            Assert.Equal("Acme Inc", response.CurrentCarrier.Name);
+            Assert.Equal("GB", response.CurrentCarrier.Country);
+            Assert.Equal("mobile", response.CurrentCarrier.NetworkType);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void TestAdvancedNIRequestSyncWithNullableValues(bool passCreds, bool kitchenSink)
+        {//ARRANGE
+            var expectedResponse = @"{
+              ""status"": 0,
+              ""status_message"": ""Success"",
+              ""request_id"": ""aaaaaaaa-bbbb-cccc-dddd-0123456789ab"",
+              ""international_format_number"": ""447700900000"",
+              ""national_format_number"": ""07700 900000"",
+              ""country_code"": ""GB"",
+              ""country_code_iso3"": ""GBR"",
+              ""country_name"": ""United Kingdom"",
+              ""country_prefix"": ""44"",
+              ""request_price"": ""0.04000000"",
+              ""refund_price"": ""0.01500000"",
+              ""remaining_balance"": ""1.23456789"",
+              ""current_carrier"": {
+                ""network_code"": ""12345"",
+                ""name"": ""Acme Inc"",
+                ""country"": ""GB"",
+                ""network_type"": ""mobile""
+              },
+              ""original_carrier"": {
+                ""network_code"": ""12345"",
+                ""name"": ""Acme Inc"",
+                ""country"": ""GB"",
+                ""network_type"": ""mobile""
+              },
+              ""ported"": null,
+              ""roaming"": null,
+              ""caller_identity"": {
+                            ""caller_type"": ""consumer"",
+                ""caller_name"": ""John Smith"",
+                ""first_name"": ""John"",
+                ""last_name"": ""Smith""
+              },
+              ""caller_name"": ""John Smith"",
+              ""last_name"": ""Smith"",
+              ""first_name"": ""John"",
+              ""caller_type"": ""consumer"",
+              ""lookup_outcome"": 0,
+              ""lookup_outcome_message"": ""Success"",
+              ""valid_number"": ""valid"",
+              ""reachable"": null
+            }";
+
+            var expectedUri = $"{ApiUrl}/ni/advanced/json";
+            AdvancedNumberInsightRequest request;
+            if (kitchenSink)
+            {
+                expectedUri += $"?ip={HttpUtility.UrlEncode("123.0.0.255")}&cnam=true&number=15555551212&country=GB&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new AdvancedNumberInsightRequest { Cnam = true, Country = "GB", Number = "15555551212" , Ip="123.0.0.255"};
+            }
+            else
+            {
+                expectedUri += $"?number=15555551212&api_key={ApiKey}&api_secret={ApiSecret}&";
+                request = new AdvancedNumberInsightRequest
+                {
+                    Number = "15555551212"
+                };
+            }
+
+            Setup(expectedUri, expectedResponse);
+
+            //ACT
+            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var client = new VonageClient(creds);
+            AdvancedInsightsResponse response;
+            if (passCreds)
+            {
+                response = client.NumberInsightClient.GetNumberInsightAdvanced(request, creds);
+            }
+            else
+            {
+                response = client.NumberInsightClient.GetNumberInsightAdvanced(request);
+            }
+
+            //ASSERT
+            Assert.Null(response.Reachable);
+            Assert.Equal(NumberValidity.valid, response.ValidNumber);
+            Assert.Equal("Success", response.LookupOutcomeMessage);
+            Assert.Equal(0, response.LookupOutcome);
+            Assert.Equal("John", response.FirstName);
+            Assert.Equal(CallerType.consumer, response.CallerType);
+            Assert.Equal("Smith", response.LastName);
+            Assert.Equal("John Smith", response.CallerName);
+            Assert.Equal("Smith", response.CallerIdentity.LastName);
+            Assert.Equal("John", response.CallerIdentity.FirstName);
+            Assert.Equal("John Smith", response.CallerIdentity.CallerName);
+            Assert.Equal(CallerType.consumer, response.CallerIdentity.CallerType);
+            Assert.Null(response.Roaming);
+            Assert.Null(response.Ported);
             Assert.Equal("12345", response.OriginalCarrier.NetworkCode);
             Assert.Equal("Acme Inc", response.OriginalCarrier.Name);
             Assert.Equal("GB", response.OriginalCarrier.Country);

--- a/Vonage/NumberInsights/AdvancedInsightsResponse.cs
+++ b/Vonage/NumberInsights/AdvancedInsightsResponse.cs
@@ -34,6 +34,6 @@ namespace Vonage.NumberInsights
         /// </summary>
         [JsonProperty("reachable")]
         [JsonConverter(typeof(StringEnumConverter))]
-        public NumberReachability Reachable { get; set; }
+        public NumberReachability? Reachable { get; set; }
     }
 }

--- a/Vonage/NumberInsights/StandardInsightResponse.cs
+++ b/Vonage/NumberInsights/StandardInsightResponse.cs
@@ -44,12 +44,13 @@ namespace Vonage.NumberInsights
         /// </summary>
         [JsonProperty("ported")]
         [JsonConverter(typeof(StringEnumConverter))]
-        public PortedStatus Ported { get; set; }
+        public PortedStatus? Ported { get; set; }
 
         /// <summary>
         /// Information about the roaming status for number. This is applicable to mobile numbers only.
         /// </summary>
         [JsonProperty("roaming")]
+        [JsonConverter(typeof(StringOrObjectConverter<string>))]
         public Roaming Roaming { get; set; }
 
         /// <summary>

--- a/Vonage/NumberInsights/StringOrObjectConverter.cs
+++ b/Vonage/NumberInsights/StringOrObjectConverter.cs
@@ -1,0 +1,56 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Vonage.NumberInsights
+{
+    class StringOrObjectConverter<T> : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return (objectType == typeof(Roaming));
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.Path.ToString() == "roaming" && reader.Value == null)
+            {
+                if (reader.TokenType == JsonToken.StartObject) {
+                    var obj = JObject.Load(reader);
+
+                    RoamingStatus status;
+                    if(!Enum.TryParse(obj["status"].ToString(), out status))
+                    {
+                        status = RoamingStatus.unknown;
+                    }
+
+                    return new Roaming {
+                        Status = status,
+                        RoamingCountryCode = obj["roaming_country_code"].ToString(),
+                        RoamingNetworkCode = obj["roaming_network_code"].ToString(),
+                        RoamingNetworkName = obj["roaming_network_name"].ToString()
+                    };
+                }
+
+                return null;
+            }
+
+            if (reader.Path.ToString() == "roaming" && reader.Value.ToString() == RoamingStatus.unknown.ToString())
+            {
+                return new Roaming
+                {
+                    Status = RoamingStatus.unknown
+                };
+            }
+
+            throw new FormatException("Invalid Number Insights Roaming data detected");
+        }
+
+        public override bool CanWrite => base.CanWrite;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
The Number Insights API changed their response for various fields to indicate when we are missing info versus the data is just unknown. This adds null support to:

* Current Carrier child values
* `reachable`
* `ported`
* `roaming`

It also adds support for `roaming` to return a string value, but be parsed into the old object format.