### PR TITLE
Replace Dictionary with ConcurrentDictionary

### DIFF
--- a/Vonage/Logger/LogProvider.cs
+++ b/Vonage/Logger/LogProvider.cs
@@ -1,12 +1,14 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System;
+
 namespace Vonage.Logger
 {
     public class LogProvider
     {
-        private static IDictionary<string, ILogger> _loggers = new Dictionary<string, ILogger>();
+        private static IDictionary<string, ILogger> _loggers = new ConcurrentDictionary<string, ILogger>();
         private static ILoggerFactory _loggerFactory = new LoggerFactory();
 
         public static void SetLogFactory(ILoggerFactory factory)
@@ -20,7 +22,7 @@ namespace Vonage.Logger
         {
             if (!_loggers.ContainsKey(category))
             {
-                _loggers[category] = _loggerFactory?.CreateLogger(category)?? NullLogger.Instance;
+                _loggers[category] = _loggerFactory?.CreateLogger(category) ?? NullLogger.Instance;
             }
             return _loggers[category];
         }


### PR DESCRIPTION
VCC Incident on the 23rd of November 2021 we believe caused by this static function using a non thread safe Dictionary.

The incident in question.

https://vonage.slack.com/archives/CFZ9H9AKG/p1637659099179000
https://newvoicemedia.my.salesforce.com/a9t4G0000004FtYQAU


stack from logging during incident:

```
 "StackTrace": " at System.Collections.Generic.Dictionary`2.TryInsert(TKey key, TValue value, InsertionBehavior behavior)\n at System.Collections.Generic.Dictionary`2.set_Item(TKey key, TValue value)\n at Vonage.Logger.LogProvider.GetLogger(String category)\n at Vonage.PemParse.DecodePEMKey(String pemstr)\n at NewVoiceMedia.WebRtc.Nexmo.NexmoToken.CreateToken(Dictionary`2 payload, String region) in /home/src/WebRtc/Nexmo/NexmoToken.cs:line 29\n at NewVoiceMedia.WebRtc.Controllers.TokenController.Nexmo(String agentLocation) in /home/src/WebRtc/Controllers/TokenController.cs:line 93"
  },
```

