### PR TITLE
Remove specific .net versioning for mutation pipeline

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -6,10 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.401'
       - name: Install Stryker
         run: dotnet tool install -g dotnet-stryker
       - name: Run mutation testing


### PR DESCRIPTION
I had to fix the workflow given Stryker was not compatible with .Net Core 3.1 🧟 

Here's the proof it works (ran from the branch): https://github.com/Vonage/vonage-dotnet-sdk/actions/runs/3182422444
The mutation report is available as workflow artifact.