### PR TITLE
SonarCloud integration

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.0'
+          dotnet-version: '3.1.401'
       - name: Clean
         run: dotnet clean Vonage.sln --configuration Release && dotnet nuget locals all --clear
       - name: Restore NuGets

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -8,26 +8,37 @@ on:
 
 jobs:
   build:
-
     runs-on: windows-latest
-
-    steps:        
-    - uses: actions/checkout@v2        
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.401'
-    - name: Clean
-      run: dotnet clean Vonage.sln --configuration Release && dotnet nuget locals all --clear
-    - name: Install dependencies
-      run: |
-        dotnet restore
-        choco install opencover.portable
-        choco install codecov
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-    - name: Test
-      run: |          
-        dotnet test --no-restore
-        OpenCover.Console.exe -register:users -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:"test  $Env:GITHUB_WORKSPACE\vonage.sln -f netcoreapp3.0" -output:".\Vonage-Dotnet-coverage.xml"
-        codecov -f "Vonage-Dotnet-coverage.xml"    
+    steps:
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - name: Install SonarCloud scanner
+        run: |
+          dotnet tool update --global dotnet-sonarscanner
+      - name: Install coverlet
+        id: install-coverlet
+        run: |
+          dotnet tool install --global dotnet-coverage
+      - uses: actions/checkout@v2
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.403'
+      - name: Clean
+        run: dotnet clean Vonage.sln --configuration Release && dotnet nuget locals all --clear
+      - name: Begin SonarScanner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: dotnet-sonarscanner begin /k:"Vonage_vonage-dotnet-sdk" /o:"vonage" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Test
+        run: dotnet-coverage collect 'dotnet test --no-build' -f xml  -o 'coverage.xml'
+      - name: End SonarScanner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.401'
+          dotnet-version: '3.1.7'
       - name: Clean
         run: dotnet clean Vonage.sln --configuration Release && dotnet nuget locals all --clear
       - name: Restore NuGets

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore
       - name: Test
-        run: dotnet-coverage collect 'dotnet test --no-build' -f xml  -o 'coverage.xml'
+        run: dotnet-coverage collect 'dotnet test  --configuration Release --no-build' -f xml  -o 'coverage.xml'
       - name: End SonarScanner
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.7'
+          dotnet-version: '6.0.403'
       - name: Clean
         run: dotnet clean Vonage.sln --configuration Release && dotnet nuget locals all --clear
       - name: Restore NuGets

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -22,10 +22,14 @@ jobs:
         run: |
           dotnet tool install --global dotnet-coverage
       - uses: actions/checkout@v2
-      - name: Setup .NET
+      - name: Setup .NET 6.0
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '6.0.403'
+      - name: Setup .NET 3.1
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.401'
       - name: Clean
         run: dotnet clean Vonage.sln --configuration Release && dotnet nuget locals all --clear
       - name: Restore NuGets

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -28,6 +28,8 @@ jobs:
           dotnet-version: '6.0.403'
       - name: Clean
         run: dotnet clean Vonage.sln --configuration Release && dotnet nuget locals all --clear
+      - name: Restore NuGets
+        run: dotnet restore
       - name: Begin SonarScanner
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0.403'
+          dotnet-version: '3.1.401'
       - name: Clean
         run: dotnet clean Vonage.sln --configuration Release && dotnet nuget locals all --clear
       - name: Restore NuGets

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.401'
+          dotnet-version: '5.0.0'
       - name: Clean
         run: dotnet clean Vonage.sln --configuration Release && dotnet nuget locals all --clear
       - name: Restore NuGets

--- a/Vonage.Test.Unit/Vonage.Test.Unit.csproj
+++ b/Vonage.Test.Unit/Vonage.Test.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net462;net47;net471;net472;net6.0;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net462;net47;net471;net472;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
 		<NoWarn>1701;1702;0618</NoWarn>
 		<IsPackable>false</IsPackable>
 		<Configurations>Debug;Release;ReleaseSigned</Configurations>

--- a/Vonage.Test.Unit/Vonage.Test.Unit.csproj
+++ b/Vonage.Test.Unit/Vonage.Test.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net462;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;net47;net471;net472;net48;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net462;net47;net471;net472;net6.0;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
 		<NoWarn>1701;1702;0618</NoWarn>
 		<IsPackable>false</IsPackable>
 		<Configurations>Debug;Release;ReleaseSigned</Configurations>

--- a/Vonage.Test.Unit/Vonage.Test.Unit.csproj
+++ b/Vonage.Test.Unit/Vonage.Test.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net462;net47;net471;net472;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net462;net47;net471;net472;netcoreapp3.1</TargetFrameworks>
 		<NoWarn>1701;1702;0618</NoWarn>
 		<IsPackable>false</IsPackable>
 		<Configurations>Debug;Release;ReleaseSigned</Configurations>


### PR DESCRIPTION
Add SonarCloud analysis in the main pipeline.
Add .net6 as a client framework for the test project, given Core3.1 will get out-of-support this month.