### PR TITLE
Sonarcloud integration

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -8,26 +8,46 @@ on:
 
 jobs:
   build:
-
     runs-on: windows-latest
+    steps:
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - name: Setup .NET 6.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.403'
+      - name: Setup .NET 3.1
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.401'
 
-    steps:        
-    - uses: actions/checkout@v2        
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.401'
-    - name: Clean
-      run: dotnet clean Vonage.sln --configuration Release && dotnet nuget locals all --clear
-    - name: Install dependencies
-      run: |
-        dotnet restore
-        choco install opencover.portable
-        choco install codecov
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-    - name: Test
-      run: |          
-        dotnet test --no-restore
-        OpenCover.Console.exe -register:users -target:"C:\Program Files\dotnet\dotnet.exe" -targetargs:"test  $Env:GITHUB_WORKSPACE\vonage.sln -f netcoreapp3.0" -output:".\Vonage-Dotnet-coverage.xml"
-        codecov -f "Vonage-Dotnet-coverage.xml"    
+      - name: Install SonarScanner
+        run: |
+          dotnet tool update --global dotnet-sonarscanner
+      - name: Install coverlet
+        id: install-coverlet
+        run: |
+          dotnet tool install --global dotnet-coverage
+
+      - uses: actions/checkout@v2
+      - name: Clean
+        run: dotnet clean Vonage.sln --configuration Release && dotnet nuget locals all --clear
+      - name: Restore NuGets
+        run: dotnet restore
+        
+      - name: Begin SonarScanner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: dotnet-sonarscanner begin /k:"Vonage_vonage-dotnet-sdk" /o:"vonage" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Test
+        run: dotnet-coverage collect 'dotnet test  --configuration Release --no-build' -f xml  -o 'coverage.xml'
+      - name: End SonarScanner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"

--- a/Vonage.Test.Unit/Vonage.Test.Unit.csproj
+++ b/Vonage.Test.Unit/Vonage.Test.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net462;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;net47;net471;net472;net48;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net462;net47;net471;net472;net6.0;netcoreapp3.1</TargetFrameworks>
 		<NoWarn>1701;1702;0618</NoWarn>
 		<IsPackable>false</IsPackable>
 		<Configurations>Debug;Release;ReleaseSigned</Configurations>

--- a/Vonage.Test.Unit/Vonage.Test.Unit.csproj
+++ b/Vonage.Test.Unit/Vonage.Test.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net462;net47;net471;net472;net6.0;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net462;net47;net471;net472;net48;net6.0;netcoreapp3.1</TargetFrameworks>
 		<NoWarn>1701;1702;0618</NoWarn>
 		<IsPackable>false</IsPackable>
 		<Configurations>Debug;Release;ReleaseSigned</Configurations>


### PR DESCRIPTION
Add SonarCloud analysis in the main pipeline
Remove unsupported client frameworks (.net core < 3.1)
Add .Net6 client framework given .NetCore3.1 will get out-of-support this month