### PR TITLE
DEVX-6785 Framework update

### DIFF
--- a/Vonage.Test.Unit/Vonage.Test.Unit.csproj
+++ b/Vonage.Test.Unit/Vonage.Test.Unit.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net462;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;net47;net471;net472;net48;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
 		<NoWarn>1701;1702;0618</NoWarn>
 		<IsPackable>false</IsPackable>
 		<Configurations>Debug;Release;ReleaseSigned</Configurations>
+		<TargetFrameworks>net462;net47;net471;net472;net6.0;net6.0-windows;netcoreapp3.1</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net461|AnyCPU'">
@@ -118,11 +118,17 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-		<PackageReference Include="Moq" Version="4.13.1" />
-		<PackageReference Include="xunit" Version="2.4.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-		<PackageReference Include="coverlet.collector" Version="1.0.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0"/>
+		<PackageReference Include="Moq" Version="4.18.2"/>
+		<PackageReference Include="xunit" Version="2.4.2"/>
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.2.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>
@@ -337,99 +343,48 @@
 	  </None>
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
-	    <Version>5.0.0</Version>
-	  </PackageReference>
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net462'">
-	  <PackageReference Include="Microsoft.Extensions.Logging">
-	    <Version>5.0.0</Version>
-	  </PackageReference>
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
-	    <Version>5.0.0</Version>
-	  </PackageReference>
-	</ItemGroup>
-
 	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
 	  <PackageReference Include="Microsoft.Extensions.Logging">
-	    <Version>5.0.0</Version>
+		  <Version>7.0.0</Version>
 	  </PackageReference>
 	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
-	    <Version>5.0.0</Version>
+		  <Version>7.0.0</Version>
 	  </PackageReference>
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
 	  <PackageReference Include="Microsoft.Extensions.Logging">
-	    <Version>5.0.0</Version>
+		  <Version>7.0.0</Version>
 	  </PackageReference>
 	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
-	    <Version>5.0.0</Version>
+		  <Version>7.0.0</Version>
 	  </PackageReference>
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
 	  <PackageReference Include="Microsoft.Extensions.Logging">
-	    <Version>5.0.0</Version>
+		  <Version>7.0.0</Version>
 	  </PackageReference>
 	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
-	    <Version>5.0.0</Version>
-	  </PackageReference>
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net47'">
-	  <PackageReference Include="Microsoft.Extensions.Logging">
-	    <Version>5.0.0</Version>
-	  </PackageReference>
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
-	    <Version>5.0.0</Version>
-	  </PackageReference>
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net471'">
-	  <PackageReference Include="Microsoft.Extensions.Logging">
-	    <Version>5.0.0</Version>
-	  </PackageReference>
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
-	    <Version>5.0.0</Version>
-	  </PackageReference>
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-	  <PackageReference Include="Microsoft.Extensions.Logging">
-	    <Version>5.0.0</Version>
-	  </PackageReference>
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
-	    <Version>5.0.0</Version>
-	  </PackageReference>
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-	  <PackageReference Include="Microsoft.Extensions.Logging">
-	    <Version>5.0.0</Version>
-	  </PackageReference>
-	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
-	    <Version>5.0.0</Version>
+		  <Version>7.0.0</Version>
 	  </PackageReference>
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
 	  <PackageReference Include="Microsoft.Extensions.Logging">
-	    <Version>5.0.0</Version>
+		  <Version>7.0.0</Version>
 	  </PackageReference>
 	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
-	    <Version>5.0.0</Version>
+		  <Version>7.0.0</Version>
 	  </PackageReference>
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
 	  <PackageReference Include="Microsoft.Extensions.Logging">
-	    <Version>5.0.0</Version>
+		  <Version>7.0.0</Version>
 	  </PackageReference>
 	  <PackageReference Include="Microsoft.Extensions.Logging.Abstractions">
-	    <Version>5.0.0</Version>
+		  <Version>7.0.0</Version>
 	  </PackageReference>
 	</ItemGroup>
 

--- a/Vonage.Test.Unit/Vonage.Test.Unit.csproj
+++ b/Vonage.Test.Unit/Vonage.Test.Unit.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
+		<TargetFrameworks>net462;net47;net471;net472;net48;net6.0;net6.0-windows;netcoreapp3.1</TargetFrameworks>
 		<NoWarn>1701;1702;0618</NoWarn>
 		<IsPackable>false</IsPackable>
 		<Configurations>Debug;Release;ReleaseSigned</Configurations>
-		<TargetFrameworks>net462;net47;net471;net472;net6.0;net6.0-windows;netcoreapp3.1</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net461|AnyCPU'">
@@ -119,7 +119,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0"/>
-		<PackageReference Include="Moq" Version="4.18.2"/>
+		<PackageReference Include="Moq" Version="4.18.3"/>
 		<PackageReference Include="xunit" Version="2.4.2"/>
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<PrivateAssets>all</PrivateAssets>

--- a/Vonage/Vonage.csproj
+++ b/Vonage/Vonage.csproj
@@ -32,7 +32,7 @@
     <PackageIconUrl/>
     <Description>Official C#/.NET wrapper for the Vonage API. To use it you will need a Vonage account. Sign up for free at vonage.com. For full API documentation refer to developer.vonage.com.
 	</Description>
-    <LangVersion>9</LangVersion>
+    <LangVersion>10</LangVersion>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">

--- a/Vonage/Vonage.csproj
+++ b/Vonage/Vonage.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0"/>
-    <PackageReference Include="jose-jwt" Version="4.0.1"/>
+    <PackageReference Include="jose-jwt" Version="4.1.0"/>
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0"/>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2"/>
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"/>
@@ -67,7 +67,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0"/>
-    <PackageReference Include="jose-jwt" Version="4.0.1"/>
+    <PackageReference Include="jose-jwt" Version="4.1.0"/>
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0"/>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2"/>
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"/>

--- a/Vonage/Vonage.csproj
+++ b/Vonage/Vonage.csproj
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net452;net46</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Vonage</AssemblyName>
     <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">2.0.0</NetStandardImplicitPackageVersion>
@@ -34,6 +33,7 @@
     <Description>Official C#/.NET wrapper for the Vonage API. To use it you will need a Vonage account. Sign up for free at vonage.com. For full API documentation refer to developer.vonage.com.
 	</Description>
     <LangVersion>9</LangVersion>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
     <DefineConstants>LIBLOG_PORTABLE</DefineConstants>
@@ -54,28 +54,28 @@
     <DelaySign>false</DelaySign>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2"/>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2"/>
-    <PackageReference Include="jose-jwt" Version="2.3.*"/>
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.*"/>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1"/>
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0"/>
+    <PackageReference Include="jose-jwt" Version="4.0.1"/>
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0"/>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2"/>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"/>
     <PackageReference Include="System.Net.Http" Version="4.3.4"/>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2"/>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2"/>
-    <PackageReference Include="jose-jwt" Version="2.3.*"/>
-    <PackageReference Include="System.Collections.Immutable" Version="1.2.*"/>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1"/>
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0"/>
+    <PackageReference Include="jose-jwt" Version="4.0.1"/>
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0"/>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2"/>
+    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0"/>
     <PackageReference Include="System.Net.Http" Version="4.3.4"/>
-    <PackageReference Include="System.Diagnostics.Process" Version="4.1.*"/>
+    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0"/>
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1"/>
-    <PackageReference Include="System.Security.Cryptography.OpenSsl" Version="4.4.0"/>
-    <PackageReference Include="System.Security.Cryptography.Cng" Version="4.4.0"/>
+    <PackageReference Include="System.Security.Cryptography.OpenSsl" Version="5.0.0"/>
+    <PackageReference Include="System.Security.Cryptography.Cng" Version="5.0.0"/>
   </ItemGroup>
   <ItemGroup>
     <None Include="VonageLogo_Symbol_Black.png">
@@ -84,8 +84,8 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
     <PackageReference Include="System.ComponentModel" Version="4.3.0"/>
-    <PackageReference Include="System.ComponentModel.Composition" Version="4.7.0"/>
+    <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Upgrade SDK to netstandard2.0, Upgrade TestProject to everything above 4.6.2, and update all libraries.

NetStandard2.0 represents a unified version of the framework that covers all supported versions. Switching to a "netstandard2.0" target version makes it easier for us in dependency management and guarantees we're aligned with support. Also, version 4.5.2 is out-of-support since April 2022.