### PR TITLE
Add unsafe methods on Maybe & Result

### DIFF
--- a/Vonage.Video.Beta.Test/Common/MaybeTest.cs
+++ b/Vonage.Video.Beta.Test/Common/MaybeTest.cs
@@ -120,6 +120,17 @@ namespace Vonage.Video.Beta.Test.Common
             CreateSome(value).GetHashCode().Should().Be(value.GetHashCode());
         }
 
+        [Fact]
+        public void GetUnsafe_ShouldReturnValue_GivenSome() =>
+            CreateSome(10).GetUnsafe().Should().Be(10);
+
+        [Fact]
+        public void GetUnsafe_ShouldThrowException_GivenNone()
+        {
+            Action act = () => Maybe<string>.None.GetUnsafe();
+            act.Should().Throw<UnsafeValueException>().WithMessage("State is None.");
+        }
+
         private static Maybe<T> CreateSome<T>(T value) => Maybe<T>.Some(value);
 
         private static string GetStaticString() => "Some value";

--- a/Vonage.Video.Beta.Test/Common/ResultTest.cs
+++ b/Vonage.Video.Beta.Test/Common/ResultTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Vonage.Video.Beta.Common;
 using Vonage.Video.Beta.Test.Extensions;
@@ -175,6 +176,28 @@ namespace Vonage.Video.Beta.Test.Common
         [Fact]
         public void Equals_ShouldReturnFalse_GivenBothAreSuccessWithDifferentValue() =>
             CreateSuccess(5).Equals(CreateSuccess(10)).Should().BeFalse();
+
+        [Fact]
+        public void GetFailureUnsafe_ShouldReturnFailure_GivenFailure() =>
+            CreateFailure().GetFailureUnsafe().Should().Be(CreateResultFailure());
+
+        [Fact]
+        public void GetFailureUnsafe_ShouldThrowException_GivenSuccess()
+        {
+            Action act = () => CreateSuccess(5).GetFailureUnsafe();
+            act.Should().Throw<UnsafeValueException>().WithMessage("State is Success.");
+        }
+
+        [Fact]
+        public void GetSuccessUnsafe_ShouldThrowException_GivenFailure()
+        {
+            Action act = () => CreateFailure().GetSuccessUnsafe();
+            act.Should().Throw<UnsafeValueException>().WithMessage("State is Failure.");
+        }
+
+        [Fact]
+        public void GetSuccessUnsafe_ShouldReturn_GivenSuccess() =>
+            CreateSuccess(5).GetSuccessUnsafe().Should().Be(5);
 
         private static Result<int> CreateSuccess(int value) => Result<int>.FromSuccess(value);
 

--- a/Vonage.Video.Beta/Common/Maybe.cs
+++ b/Vonage.Video.Beta/Common/Maybe.cs
@@ -118,4 +118,11 @@ public readonly struct Maybe<TA>
     /// <param name="value">Value to be converted.</param>
     /// <returns>None if the value is null, Some otherwise.</returns>
     public static implicit operator Maybe<TA>(TA value) => value is null ? None : Some(value);
+
+    /// <summary>
+    ///     Retrieves the Maybe's value. This method is unsafe and will throw an exception if in None state.
+    /// </summary>
+    /// <returns>The value if in Some state.</returns>
+    /// <exception cref="UnsafeValueException">When in None state.</exception>
+    public TA GetUnsafe() => this.Match(_ => _, () => throw new UnsafeValueException("State is none."));
 }

--- a/Vonage.Video.Beta/Common/Result.cs
+++ b/Vonage.Video.Beta/Common/Result.cs
@@ -167,4 +167,19 @@ public readonly struct Result<T>
     /// <returns>Asynchronous bound functor.</returns>
     public async Task<Result<TB>> BindAsync<TB>(Func<T, Task<Result<TB>>> bind) =>
         this.IsFailure ? Result<TB>.FromFailure(this.failure) : await bind(this.success);
+
+    /// <summary>
+    ///     Retrieves the Failure value. This method is unsafe and will throw an exception if in Success state.
+    /// </summary>
+    /// <returns>The Failure value when in Failure state.</returns>
+    /// <exception cref="UnsafeValueException">When in Success state.</exception>
+    public ResultFailure GetFailureUnsafe() =>
+        this.Match(_ => throw new UnsafeValueException("State is Success."), _ => _);
+
+    /// <summary>
+    ///     Retrieves the Success value. This method is unsafe and will throw an exception if in Failure state.
+    /// </summary>
+    /// <returns>The Success value if in Success state.</returns>
+    /// <exception cref="UnsafeValueException">When in Failure state.</exception>
+    public T GetSuccessUnsafe() => this.Match(_ => _, _ => throw new UnsafeValueException("State is Failure."));
 }

--- a/Vonage.Video.Beta/Common/UnsafeValueException.cs
+++ b/Vonage.Video.Beta/Common/UnsafeValueException.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Vonage.Video.Beta.Common
+{
+    /// <summary>
+    ///     Represents errors that occur during unsafe value retrieval.
+    /// </summary>
+    public class UnsafeValueException : Exception
+    {
+        /// <summary>
+        ///     Creates an UnsafeValueException.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        public UnsafeValueException(string message) : base(message)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Add "unsafe" methods to retrieve a monad value, throwing an exception if the monad is not in the expected state.
This is a provided workaround for people preferring exceptions instead of using transformation mechanisms (Match, Map, Bind)