### PR TITLE
MapAsync / BindAsync extension methods

### DIFF
--- a/Vonage.Video.Beta.Test/Common/Monads/ResultTest.cs
+++ b/Vonage.Video.Beta.Test/Common/Monads/ResultTest.cs
@@ -192,6 +192,60 @@ namespace Vonage.Video.Beta.Test.Common.Monads
         public void GetSuccessUnsafe_ShouldReturn_GivenSuccess() =>
             CreateSuccess(5).GetSuccessUnsafe().Should().Be(5);
 
+        [Fact]
+        public async Task MapAsync_ShouldReturnSuccess_GivenValueIsChainedSuccess() =>
+            (await CreateSuccess(5)
+                .MapAsync(IncrementAsync)
+                .MapAsync(IncrementAsync)
+                .MapAsync(IncrementAsync)
+                .MapAsync(IncrementAsync)
+                .MapAsync(IncrementAsync))
+            .Should().BeSuccess(10);
+
+        [Fact]
+        public async Task MapAsync_ShouldReturnFailure_GivenValueIsChainedFailure() =>
+            (await CreateFailure()
+                .MapAsync(IncrementAsync)
+                .MapAsync(IncrementAsync)
+                .MapAsync(IncrementAsync)
+                .MapAsync(IncrementAsync)
+                .MapAsync(IncrementAsync))
+            .Should()
+            .BeFailure(CreateResultFailure());
+
+        [Fact]
+        public async Task BindAsync_ShouldReturnFailure_GivenValueIsChainedFailure() =>
+            (await CreateFailure()
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(IncrementBindAsync))
+            .Should()
+            .BeFailure(CreateResultFailure());
+
+        [Fact]
+        public async Task BindAsync_ShouldReturnFailure_GivenValueBecomesFailure() =>
+            (await CreateSuccess(5)
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(value => Task.FromResult(CreateFailure()))
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(IncrementBindAsync))
+            .Should()
+            .BeFailure(CreateResultFailure());
+
+        [Fact]
+        public async Task BindAsync_ShouldReturnSuccess_GivenValueIsChainedSuccess() =>
+            (await CreateSuccess(5)
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(IncrementBindAsync))
+            .Should()
+            .BeSuccess(10);
+
         private static Result<int> CreateSuccess(int value) => Result<int>.FromSuccess(value);
 
         private static Result<int> CreateFailure() =>

--- a/Vonage.Video.Beta.Test/Common/Monads/ResultTest.cs
+++ b/Vonage.Video.Beta.Test/Common/Monads/ResultTest.cs
@@ -11,6 +11,87 @@ namespace Vonage.Video.Beta.Test.Common.Monads
     public class ResultTest
     {
         [Fact]
+        public void Bind_ShouldReturnFailure_GivenValueIsFailure() =>
+            CreateFailure()
+                .Bind(IncrementBind)
+                .Should()
+                .BeFailure(CreateResultFailure());
+
+        [Fact]
+        public void Bind_ShouldReturnSuccess_GivenValueIsSuccess() =>
+            CreateSuccess(5)
+                .Bind(IncrementBind)
+                .Should()
+                .BeSuccess(6);
+
+        [Fact]
+        public async Task BindAsync_ShouldReturnFailure_GivenValueBecomesFailure() =>
+            (await CreateSuccess(5)
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(value => Task.FromResult(CreateFailure()))
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(IncrementBindAsync))
+            .Should()
+            .BeFailure(CreateResultFailure());
+
+        [Fact]
+        public async Task BindAsync_ShouldReturnFailure_GivenValueIsChainedFailure() =>
+            (await CreateFailure()
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(IncrementBindAsync))
+            .Should()
+            .BeFailure(CreateResultFailure());
+
+        [Fact]
+        public async Task BindAsync_ShouldReturnFailure_GivenValueIsFailure() =>
+            (await CreateFailure()
+                .BindAsync(IncrementBindAsync))
+            .Should()
+            .BeFailure(CreateResultFailure());
+
+        [Fact]
+        public async Task BindAsync_ShouldReturnSuccess_GivenValueIsChainedSuccess() =>
+            (await CreateSuccess(5)
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(IncrementBindAsync)
+                .BindAsync(IncrementBindAsync))
+            .Should()
+            .BeSuccess(10);
+
+        [Fact]
+        public async Task BindAsync_ShouldReturnSuccess_GivenValueIsSuccess() =>
+            (await CreateSuccess(5)
+                .BindAsync(IncrementBindAsync))
+            .Should()
+            .BeSuccess(6);
+
+        [Fact]
+        public void Equals_ShouldReturnFalse_GivenBothAreSuccessWithDifferentValue() =>
+            CreateSuccess(5).Equals(CreateSuccess(10)).Should().BeFalse();
+
+        [Fact]
+        public void Equals_ShouldReturnFalse_GivenOneIsFailureAndOtherIsSuccess() =>
+            CreateSuccess(10).Equals(CreateFailure()).Should().BeFalse();
+
+        [Fact]
+        public void Equals_ShouldReturnFalse_GivenOneIsSuccessAndOtherIsFailure() =>
+            CreateFailure().Equals(CreateSuccess(10)).Should().BeFalse();
+
+        [Fact]
+        public void Equals_ShouldReturnTrue_GivenBothAreNone() =>
+            Maybe<int>.None.Equals(Maybe<int>.None).Should().BeTrue();
+
+        [Fact]
+        public void Equals_ShouldReturnTrue_GivenBothAreSuccessWithSameValue() =>
+            CreateSuccess(10).Equals(CreateSuccess(10)).Should().BeTrue();
+
+        [Fact]
         public void FromError_ShouldReturnError()
         {
             var result = CreateFailure();
@@ -27,74 +108,15 @@ namespace Vonage.Video.Beta.Test.Common.Monads
         }
 
         [Fact]
-        public void Map_ShouldReturnFailure_GivenValueIsFailure() =>
-            CreateFailure()
-                .Map(Increment)
-                .Should()
-                .BeFailure(CreateResultFailure());
+        public void GetFailureUnsafe_ShouldReturnFailure_GivenFailure() =>
+            CreateFailure().GetFailureUnsafe().Should().Be(CreateResultFailure());
 
         [Fact]
-        public async Task MapAsync_ShouldReturnFailure_GivenValueIsFailure() =>
-            (await CreateFailure()
-                .MapAsync(IncrementAsync))
-            .Should()
-            .BeFailure(CreateResultFailure());
-
-        [Fact]
-        public void Map_ShouldReturnSuccess_GivenValueIsSuccess() =>
-            CreateSuccess(5)
-                .Map(Increment)
-                .Should()
-                .BeSuccess(6);
-
-        [Fact]
-        public async Task MapAsync_ShouldReturnSuccess_GivenValueIsSuccess() =>
-            (await CreateSuccess(5)
-                .MapAsync(IncrementAsync))
-            .Should()
-            .BeSuccess(6);
-
-        [Fact]
-        public void Bind_ShouldReturnFailure_GivenValueIsFailure() =>
-            CreateFailure()
-                .Bind(IncrementBind)
-                .Should()
-                .BeFailure(CreateResultFailure());
-
-        [Fact]
-        public async Task BindAsync_ShouldReturnFailure_GivenValueIsFailure() =>
-            (await CreateFailure()
-                .BindAsync(IncrementBindAsync))
-            .Should()
-            .BeFailure(CreateResultFailure());
-
-        [Fact]
-        public void Bind_ShouldReturnSuccess_GivenValueIsSuccess() =>
-            CreateSuccess(5)
-                .Bind(IncrementBind)
-                .Should()
-                .BeSuccess(6);
-
-        [Fact]
-        public async Task BindAsync_ShouldReturnSuccess_GivenValueIsSuccess() =>
-            (await CreateSuccess(5)
-                .BindAsync(IncrementBindAsync))
-            .Should()
-            .BeSuccess(6);
-
-        [Fact]
-        public void Match_ShouldReturnFailureOperation_GivenValueIsFailure() =>
-            CreateFailure()
-                .Match(value => value.ToString(), failure => failure.GetFailureMessage())
-                .Should()
-                .Be("Some error");
-
-        [Fact]
-        public void Match_ShouldReturnSuccessOperation_GivenValueIsSuccess() =>
-            CreateSuccess(5)
-                .Match(Increment, _ => 0)
-                .Should()
-                .Be(6);
+        public void GetFailureUnsafe_ShouldThrowException_GivenSuccess()
+        {
+            Action act = () => CreateSuccess(5).GetFailureUnsafe();
+            act.Should().Throw<UnsafeValueException>().WithMessage("State is Success.");
+        }
 
         [Fact]
         public void GetHashCode_ShouldReturnValue_GivenFailure()
@@ -111,11 +133,14 @@ namespace Vonage.Video.Beta.Test.Common.Monads
         }
 
         [Fact]
-        public void ImplicitOperator_ShouldConvertToSuccess_GivenValueIsSuccess()
+        public void GetSuccessUnsafe_ShouldReturn_GivenSuccess() =>
+            CreateSuccess(5).GetSuccessUnsafe().Should().Be(5);
+
+        [Fact]
+        public void GetSuccessUnsafe_ShouldThrowException_GivenFailure()
         {
-            const int value = 55;
-            Result<int> result = value;
-            result.Should().BeSuccess(value);
+            Action act = () => CreateFailure().GetSuccessUnsafe();
+            act.Should().Throw<UnsafeValueException>().WithMessage("State is Failure.");
         }
 
         [Fact]
@@ -135,12 +160,20 @@ namespace Vonage.Video.Beta.Test.Common.Monads
         }
 
         [Fact]
-        public void IfSuccess_ShouldNotBeExecuted_GivenValueIsFailure()
-        {
-            var test = 10;
-            CreateFailure().IfSuccess(_ => test = 0);
-            test.Should().Be(10);
-        }
+        public void IfFailure_ShouldReturnDefaultValue_GivenValueIsFailure() =>
+            CreateFailure().IfFailure(10).Should().Be(10);
+
+        [Fact]
+        public void IfFailure_ShouldReturnFailureOperation_GivenValueIsFailure() =>
+            CreateFailure().IfFailure(_ => 0).Should().Be(0);
+
+        [Fact]
+        public void IfFailure_ShouldReturnSuccess_GivenValueIsSuccess() =>
+            CreateSuccess(50).IfFailure(0).Should().Be(50);
+
+        [Fact]
+        public void IfFailure_ShouldReturnSuccessOperation_GivenValueIsSuccess2() =>
+            CreateSuccess(50).IfFailure(_ => 0).Should().Be(50);
 
         [Fact]
         public void IfSuccess_ShouldBeExecuted_GivenValueIsSuccess()
@@ -151,56 +184,34 @@ namespace Vonage.Video.Beta.Test.Common.Monads
         }
 
         [Fact]
-        public void Equals_ShouldReturnTrue_GivenBothAreNone() =>
-            Maybe<int>.None.Equals(Maybe<int>.None).Should().BeTrue();
-
-        [Fact]
-        public void Equals_ShouldReturnTrue_GivenBothAreSuccessWithSameValue() =>
-            CreateSuccess(10).Equals(CreateSuccess(10)).Should().BeTrue();
-
-        [Fact]
-        public void Equals_ShouldReturnFalse_GivenOneIsFailureAndOtherIsSuccess() =>
-            CreateSuccess(10).Equals(CreateFailure()).Should().BeFalse();
-
-        [Fact]
-        public void Equals_ShouldReturnFalse_GivenOneIsSuccessAndOtherIsFailure() =>
-            CreateFailure().Equals(CreateSuccess(10)).Should().BeFalse();
-
-        [Fact]
-        public void Equals_ShouldReturnFalse_GivenBothAreSuccessWithDifferentValue() =>
-            CreateSuccess(5).Equals(CreateSuccess(10)).Should().BeFalse();
-
-        [Fact]
-        public void GetFailureUnsafe_ShouldReturnFailure_GivenFailure() =>
-            CreateFailure().GetFailureUnsafe().Should().Be(CreateResultFailure());
-
-        [Fact]
-        public void GetFailureUnsafe_ShouldThrowException_GivenSuccess()
+        public void IfSuccess_ShouldNotBeExecuted_GivenValueIsFailure()
         {
-            Action act = () => CreateSuccess(5).GetFailureUnsafe();
-            act.Should().Throw<UnsafeValueException>().WithMessage("State is Success.");
+            var test = 10;
+            CreateFailure().IfSuccess(_ => test = 0);
+            test.Should().Be(10);
         }
 
         [Fact]
-        public void GetSuccessUnsafe_ShouldThrowException_GivenFailure()
+        public void ImplicitOperator_ShouldConvertToSuccess_GivenValueIsSuccess()
         {
-            Action act = () => CreateFailure().GetSuccessUnsafe();
-            act.Should().Throw<UnsafeValueException>().WithMessage("State is Failure.");
+            const int value = 55;
+            Result<int> result = value;
+            result.Should().BeSuccess(value);
         }
 
         [Fact]
-        public void GetSuccessUnsafe_ShouldReturn_GivenSuccess() =>
-            CreateSuccess(5).GetSuccessUnsafe().Should().Be(5);
+        public void Map_ShouldReturnFailure_GivenValueIsFailure() =>
+            CreateFailure()
+                .Map(Increment)
+                .Should()
+                .BeFailure(CreateResultFailure());
 
         [Fact]
-        public async Task MapAsync_ShouldReturnSuccess_GivenValueIsChainedSuccess() =>
-            (await CreateSuccess(5)
-                .MapAsync(IncrementAsync)
-                .MapAsync(IncrementAsync)
-                .MapAsync(IncrementAsync)
-                .MapAsync(IncrementAsync)
-                .MapAsync(IncrementAsync))
-            .Should().BeSuccess(10);
+        public void Map_ShouldReturnSuccess_GivenValueIsSuccess() =>
+            CreateSuccess(5)
+                .Map(Increment)
+                .Should()
+                .BeSuccess(6);
 
         [Fact]
         public async Task MapAsync_ShouldReturnFailure_GivenValueIsChainedFailure() =>
@@ -214,44 +225,49 @@ namespace Vonage.Video.Beta.Test.Common.Monads
             .BeFailure(CreateResultFailure());
 
         [Fact]
-        public async Task BindAsync_ShouldReturnFailure_GivenValueIsChainedFailure() =>
+        public async Task MapAsync_ShouldReturnFailure_GivenValueIsFailure() =>
             (await CreateFailure()
-                .BindAsync(IncrementBindAsync)
-                .BindAsync(IncrementBindAsync)
-                .BindAsync(IncrementBindAsync)
-                .BindAsync(IncrementBindAsync)
-                .BindAsync(IncrementBindAsync))
+                .MapAsync(IncrementAsync))
             .Should()
             .BeFailure(CreateResultFailure());
 
         [Fact]
-        public async Task BindAsync_ShouldReturnFailure_GivenValueBecomesFailure() =>
+        public async Task MapAsync_ShouldReturnSuccess_GivenValueIsChainedSuccess() =>
             (await CreateSuccess(5)
-                .BindAsync(IncrementBindAsync)
-                .BindAsync(IncrementBindAsync)
-                .BindAsync(value => Task.FromResult(CreateFailure()))
-                .BindAsync(IncrementBindAsync)
-                .BindAsync(IncrementBindAsync))
-            .Should()
-            .BeFailure(CreateResultFailure());
+                .MapAsync(IncrementAsync)
+                .MapAsync(IncrementAsync)
+                .MapAsync(IncrementAsync)
+                .MapAsync(IncrementAsync)
+                .MapAsync(IncrementAsync))
+            .Should().BeSuccess(10);
 
         [Fact]
-        public async Task BindAsync_ShouldReturnSuccess_GivenValueIsChainedSuccess() =>
+        public async Task MapAsync_ShouldReturnSuccess_GivenValueIsSuccess() =>
             (await CreateSuccess(5)
-                .BindAsync(IncrementBindAsync)
-                .BindAsync(IncrementBindAsync)
-                .BindAsync(IncrementBindAsync)
-                .BindAsync(IncrementBindAsync)
-                .BindAsync(IncrementBindAsync))
+                .MapAsync(IncrementAsync))
             .Should()
-            .BeSuccess(10);
+            .BeSuccess(6);
 
-        private static Result<int> CreateSuccess(int value) => Result<int>.FromSuccess(value);
+        [Fact]
+        public void Match_ShouldReturnFailureOperation_GivenValueIsFailure() =>
+            CreateFailure()
+                .Match(value => value.ToString(), failure => failure.GetFailureMessage())
+                .Should()
+                .Be("Some error");
+
+        [Fact]
+        public void Match_ShouldReturnSuccessOperation_GivenValueIsSuccess() =>
+            CreateSuccess(5)
+                .Match(Increment, _ => 0)
+                .Should()
+                .Be(6);
 
         private static Result<int> CreateFailure() =>
             Result<int>.FromFailure(CreateResultFailure());
 
         private static ResultFailure CreateResultFailure() => ResultFailure.FromErrorMessage("Some error");
+
+        private static Result<int> CreateSuccess(int value) => Result<int>.FromSuccess(value);
 
         private static int Increment(int value) => value + 1;
 

--- a/Vonage.Video.Beta.Test/Video/Moderation/MuteStreams/MuteStreamsTest.cs
+++ b/Vonage.Video.Beta.Test/Video/Moderation/MuteStreams/MuteStreamsTest.cs
@@ -18,8 +18,8 @@ namespace Vonage.Video.Beta.Test.Video.Moderation.MuteStreams
     public class MuteStreamsTest
     {
         private readonly ModerationClient client;
-        private readonly Result<MuteStreamsRequest> request;
         private readonly UseCaseHelper helper;
+        private readonly Result<MuteStreamsRequest> request;
 
         public MuteStreamsTest()
         {
@@ -27,12 +27,6 @@ namespace Vonage.Video.Beta.Test.Video.Moderation.MuteStreams
             this.client = new ModerationClient(this.helper.Server.CreateClient(), () => this.helper.Token);
             this.request = BuildRequest(this.helper.Fixture);
         }
-
-        [Property]
-        public Property ShouldReturnFailure_GivenApiResponseIsError() =>
-            Prop.ForAll(
-                FsCheckExtensions.GetErrorResponses(),
-                error => this.VerifyReturnsFailureGivenStatusCodeIsFailure(error).Wait());
 
         [Property]
         public Property ShouldReturnFailure_GivenApiErrorCannotBeParsed() =>
@@ -48,18 +42,6 @@ namespace Vonage.Video.Beta.Test.Video.Moderation.MuteStreams
                         .Wait());
 
         [Fact]
-        public async Task ShouldReturnSuccess_GivenApiResponseIsSuccess()
-        {
-            var expectedResponse = this.helper.Fixture.Create<MuteStreamsResponse>();
-            this.helper.Server
-                .Given(this.CreateRequest())
-                .RespondWith(WireMockExtensions.CreateResponse(HttpStatusCode.OK,
-                    this.helper.Serializer.SerializeObject(expectedResponse)));
-            var result = await this.request.BindAsync(requestValue => this.client.MuteStreamsAsync(requestValue));
-            result.Should().BeSuccess(expectedResponse);
-        }
-
-        [Fact]
         public async Task ShouldReturnFailure_GivenApiResponseCannotBeParsed()
         {
             var body = this.helper.Fixture.Create<string>();
@@ -71,27 +53,45 @@ namespace Vonage.Video.Beta.Test.Video.Moderation.MuteStreams
             result.Should().BeFailure(ResultFailure.FromErrorMessage(expectedFailureMessage));
         }
 
+        [Property]
+        public Property ShouldReturnFailure_GivenApiResponseIsError() =>
+            Prop.ForAll(
+                FsCheckExtensions.GetErrorResponses(),
+                error => this.VerifyReturnsFailureGivenStatusCodeIsFailure(error).Wait());
+
         [Fact]
         public async Task ShouldReturnFailure_GivenRequestIsFailure() =>
             await this.helper.VerifyReturnsFailureGivenRequestIsFailure<MuteStreamsRequest, MuteStreamsResponse>(this
                 .client
                 .MuteStreamsAsync);
 
-        private IRequestBuilder CreateRequest()
+        [Fact]
+        public async Task ShouldReturnSuccess_GivenApiResponseIsSuccess()
         {
-            var serializedItems =
-                this.request
-                    .Map(value => this.helper.Serializer.SerializeObject(value.Configuration))
-                    .Match(_ => _, _ => string.Empty);
-            return WireMockExtensions
-                .CreateRequest(this.helper.Token, UseCaseHelper.GetPathFromRequest(this.request), serializedItems)
-                .UsingPost();
+            var expectedResponse = this.helper.Fixture.Create<MuteStreamsResponse>();
+            this.helper.Server
+                .Given(this.CreateRequest())
+                .RespondWith(WireMockExtensions.CreateResponse(HttpStatusCode.OK,
+                    this.helper.Serializer.SerializeObject(expectedResponse)));
+            var result = await this.request.BindAsync(requestValue => this.client.MuteStreamsAsync(requestValue));
+            result.Should().BeSuccess(expectedResponse);
         }
 
         private static Result<MuteStreamsRequest> BuildRequest(ISpecimenBuilder fixture) =>
             MuteStreamsRequest.Parse(fixture.Create<string>(),
                 fixture.Create<string>(),
                 fixture.Create<MuteStreamsRequest.MuteStreamsConfiguration>());
+
+        private IRequestBuilder CreateRequest()
+        {
+            var serializedItems =
+                this.request
+                    .Map(value => this.helper.Serializer.SerializeObject(value.Configuration))
+                    .IfFailure(string.Empty);
+            return WireMockExtensions
+                .CreateRequest(this.helper.Token, UseCaseHelper.GetPathFromRequest(this.request), serializedItems)
+                .UsingPost();
+        }
 
         private async Task VerifyReturnsFailureGivenStatusCodeIsFailure(ErrorResponse error)
         {

--- a/Vonage.Video.Beta.Test/Video/Sessions/CreateSession/CreateSessionDeserializationTest.cs
+++ b/Vonage.Video.Beta.Test/Video/Sessions/CreateSession/CreateSessionDeserializationTest.cs
@@ -22,7 +22,7 @@ namespace Vonage.Video.Beta.Test.Video.Sessions.CreateSession
                 "2_MX5hOThlMTJjYS1mM2U1LTRkZjgtYmM2Ni1mZDRiNWYzMGI5ZTl-fjE2NzI3MzY4NzgxNjJ-bi9OeFVLbkNaVjBUUnpVSmxjbURqQ3J4flB-fg";
             var response =
                 this.helper.Serializer.DeserializeObject<CreateSessionResponse[]>(this.helper.GetResponseJson());
-            var content = response.Match(_ => _, _ => throw new InvalidOperationException());
+            var content = response.IfFailure(_ => throw new InvalidOperationException());
             content.Length.Should().Be(1);
             content[0].SessionId.Should().Be(expectedId);
         }
@@ -32,7 +32,7 @@ namespace Vonage.Video.Beta.Test.Video.Sessions.CreateSession
         {
             var response =
                 this.helper.Serializer.DeserializeObject<CreateSessionResponse[]>(this.helper.GetResponseJson());
-            response.Match(_ => _, _ => throw new InvalidOperationException()).Should().BeEmpty();
+            response.IfFailure(_ => throw new InvalidOperationException()).Should().BeEmpty();
         }
     }
 }

--- a/Vonage.Video.Beta/Common/Monads/ResultExtensions.cs
+++ b/Vonage.Video.Beta/Common/Monads/ResultExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Vonage.Video.Beta.Common.Monads;
+
+/// <summary>
+///     Extensions for Result.
+/// </summary>
+public static class ResultExtensions
+{
+    /// <summary>
+    ///     Projects from one value to another.
+    /// </summary>
+    /// <param name="task">Asynchronous result.</param>
+    /// <param name="map">Asynchronous projection function.</param>
+    /// <typeparam name="TSource">Source type.</typeparam>
+    /// <typeparam name="TDestination">Resulting functor value type.</typeparam>
+    /// <returns>Asynchronous mapped functor.</returns>
+    public static async Task<Result<TDestination>> MapAsync<TSource, TDestination>(this Task<Result<TSource>> task,
+        Func<TSource, Task<TDestination>> map)
+    {
+        var result = await task;
+        return await result.MapAsync(map);
+    }
+
+    /// <summary>
+    ///     Monadic bind operation.
+    /// </summary>
+    /// <param name="task">Asynchronous result.</param>
+    /// <param name="bind">Asynchronous bind operation.</param>
+    /// <typeparam name="TSource">Source type.</typeparam>
+    /// <typeparam name="TDestination">Return type.</typeparam>
+    /// <returns>Asynchronous bound functor.</returns>
+    public static async Task<Result<TDestination>> BindAsync<TSource, TDestination>(this Task<Result<TSource>> task,
+        Func<TSource, Task<Result<TDestination>>> bind)
+    {
+        var result = await task;
+        return await result.BindAsync(bind);
+    }
+}

--- a/Vonage.Video.Beta/Video/VideoHttpClient.cs
+++ b/Vonage.Video.Beta/Video/VideoHttpClient.cs
@@ -70,12 +70,10 @@ internal class VideoHttpClient
     /// <param name="token">The token to use for authentication.</param>
     /// <returns>Success if the operation succeeds, Failure it if fails.</returns>
     internal async Task<Result<TResponse>> SendWithResponseAsync<TResponse, TRequest>(Result<TRequest> request,
-        string token) where TRequest : IVideoRequest
-    {
-        var resultResponse = await request.MapAsync(value => this.SendRequestAsync(value, token));
-        return await resultResponse.BindAsync(value =>
-            MatchResponse(value, this.ParseFailure<TResponse>, this.ParseSuccess<TResponse>));
-    }
+        string token) where TRequest : IVideoRequest =>
+        await request
+            .MapAsync(value => this.SendRequestAsync(value, token))
+            .BindAsync(value => MatchResponse(value, this.ParseFailure<TResponse>, this.ParseSuccess<TResponse>));
 
     /// <summary>
     ///     Sends a HttpRequest.
@@ -83,10 +81,9 @@ internal class VideoHttpClient
     /// <param name="request">The request to send.</param>
     /// <param name="token">The token to use for authentication.</param>
     /// <returns>Success if the operation succeeds, Failure it if fails.</returns>
-    internal async Task<Result<Unit>> SendAsync<T>(Result<T> request, string token) where T : IVideoRequest
-    {
-        var resultResponse = await request.MapAsync(value => this.SendRequestAsync(value, token));
-        return await resultResponse.BindAsync(value =>
-            MatchResponse(value, this.ParseFailure<Unit>, CreateSuccessResult));
-    }
+    internal async Task<Result<Unit>> SendAsync<T>(Result<T> request, string token) where T : IVideoRequest =>
+        await request
+            .MapAsync(value => this.SendRequestAsync(value, token))
+            .BindAsync(value =>
+                MatchResponse(value, this.ParseFailure<Unit>, CreateSuccessResult));
 }


### PR DESCRIPTION
Implement chainable extension methods for MapAsync and BindAsync on Task<Result<T>>
Implement IfFailure on Result<T> to extract the success more easily