### PR TITLE
[DEVX-6796] Remove deprecated message types (wappush, val, vcar)

### DIFF
--- a/Vonage.Test.Unit/MessagingTests.cs
+++ b/Vonage.Test.Unit/MessagingTests.cs
@@ -1,66 +1,50 @@
-﻿using Newtonsoft.Json;
-using Vonage.Messaging;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Web;
-using Xunit;
+using Newtonsoft.Json;
+using Vonage.Cryptography;
+using Vonage.Messaging;
+using Vonage.Request;
 using Vonage.Serialization;
+using Xunit;
 
 namespace Vonage.Test.Unit
 {
     public class MessagingTests : TestBase
     {
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void SendSmsWithAllPropertiesSet(bool passCreds)
+        [Fact]
+        public void NullMessagesResponse()
+        {
+            var expectedResponse = @"";
+            var expectedUri = $"{RestUrl}/sms/json";
+            var expectedRequestContent =
+                $"from=AcmeInc&to=447700900000&text={HttpUtility.UrlEncode("Hello World!")}&api_key={ApiKey}&api_secret={ApiSecret}&";
+            Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var client = new VonageClient(Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret));
+            var exception = Assert.Throws<VonageSmsResponseException>(() =>
+                client.SmsClient.SendAnSms(new SendSmsRequest
+                    {From = "AcmeInc", To = "447700900000", Text = "Hello World!"}));
+            Assert.NotNull(exception);
+            Assert.Equal($"Encountered an Empty SMS response", exception.Message);
+        }
+
+        [Fact]
+        public async Task SendSmsAsyncBadResponse()
         {
             var expectedResponse = GetExpectedJson();
             var expectedUri = $"{RestUrl}/sms/json";
-            var expectedRequestContent = $"from=AcmeInc&to=447700900000&text={HttpUtility.UrlEncode("Hello World!")}" +
-                $"&ttl=900000&status-report-req=true&callback={HttpUtility.UrlEncode("https://example.com/sms-dlr")}&message-class=0" +
-                $"&type=text&vcard=none&vcal=none&body=638265253311&udh=06050415811581&protocol-id=127&title=welcome&url={HttpUtility.UrlEncode("https://example.com")}" +
-                $"&validity=300000&client-ref=my-personal-reference&account-ref=customer1234&entity-id=testEntity&content-id=testcontent&api_key={ApiKey}&api_secret={ApiSecret}&";
-
-            var request = new SendSmsRequest
-            {
-                AccountRef = "customer1234",
-                Body = "638265253311",
-                Callback = "https://example.com/sms-dlr",
-                ClientRef = "my-personal-reference",
-                From = "AcmeInc",
-                To = "447700900000",
-                MessageClass = 0,
-                ProtocolId = 127,
-                StatusReportReq = true,
-                Text = "Hello World!",
-                Title = "welcome",
-                Ttl = 900000,
-                Type = SmsType.Text,
-                Udh = "06050415811581",
-                Validity = "300000",
-                Vcal = "none",
-                Vcard = "none",
-                Url = "https://example.com",
-                ContentId = "testcontent",
-                EntityId = "testEntity"
-            };
-
-            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var expectedRequestContent =
+                $"from=AcmeInc&to=447700900000&text={HttpUtility.UrlEncode("Hello World!")}&api_key={ApiKey}&api_secret={ApiSecret}&";
             Setup(expectedUri, expectedResponse, expectedRequestContent);
-            var client = new VonageClient(creds);
-
-            var response = passCreds
-                ? client.SmsClient.SendAnSms(request, creds)
-                : client.SmsClient.SendAnSms(request);
-
-            Assert.Equal("1", response.MessageCount);
-            Assert.Equal("447700900000", response.Messages[0].To);
-            Assert.Equal("0A0000000123ABCD1", response.Messages[0].MessageId);
-            Assert.Equal("0", response.Messages[0].Status);
-            Assert.Equal("3.14159265", response.Messages[0].RemainingBalance);
-            Assert.Equal("12345", response.Messages[0].Network);
-            Assert.Equal("customer1234", response.Messages[0].AccountRef);
+            var client = new VonageClient(Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret));
+            var exception = await Assert.ThrowsAsync<VonageSmsResponseException>(async () =>
+                await client.SmsClient.SendAnSmsAsync(new SendSmsRequest
+                    {From = "AcmeInc", To = "447700900000", Text = "Hello World!"}));
+            Assert.NotNull(exception);
+            Assert.Equal(
+                $"SMS Request Failed with status: {exception.Response.Messages[0].Status} and error message: {exception.Response.Messages[0].ErrorText}",
+                exception.Message);
+            Assert.Equal(SmsStatusCode.InvalidCredentials, exception.Response.Messages[0].StatusCode);
         }
 
         [Theory]
@@ -71,10 +55,9 @@ namespace Vonage.Test.Unit
             var expectedResponse = GetExpectedJson();
             var expectedUri = $"{RestUrl}/sms/json";
             var expectedRequestContent = $"from=AcmeInc&to=447700900000&text={HttpUtility.UrlEncode("Hello World!")}" +
-                $"&ttl=900000&status-report-req=true&callback={HttpUtility.UrlEncode("https://example.com/sms-dlr")}&message-class=0" +
-                $"&type=text&vcard=none&vcal=none&body=638265253311&udh=06050415811581&protocol-id=127&title=welcome&url={HttpUtility.UrlEncode("https://example.com")}" +
-                $"&validity=300000&client-ref=my-personal-reference&account-ref=customer1234&entity-id=testEntity&content-id=testcontent&api_key={ApiKey}&api_secret={ApiSecret}&";
-
+                                         $"&ttl=900000&status-report-req=true&callback={HttpUtility.UrlEncode("https://example.com/sms-dlr")}&message-class=0" +
+                                         "&type=text&body=638265253311&udh=06050415811581&protocol-id=127" +
+                                         $"&client-ref=my-personal-reference&account-ref=customer1234&entity-id=testEntity&content-id=testcontent&api_key={ApiKey}&api_secret={ApiSecret}&";
             var request = new SendSmsRequest
             {
                 AccountRef = "customer1234",
@@ -87,26 +70,18 @@ namespace Vonage.Test.Unit
                 ProtocolId = 127,
                 StatusReportReq = true,
                 Text = "Hello World!",
-                Title = "welcome",
                 Ttl = 900000,
                 Type = SmsType.Text,
                 Udh = "06050415811581",
-                Validity = "300000",
-                Vcal = "none",
-                Vcard = "none",
-                Url = "https://example.com",
                 ContentId = "testcontent",
                 EntityId = "testEntity"
             };
-
-            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
+            var creds = Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
             Setup(expectedUri, expectedResponse, expectedRequestContent);
             var client = new VonageClient(creds);
-
             var response = passCreds
                 ? await client.SmsClient.SendAnSmsAsync(request, creds)
                 : await client.SmsClient.SendAnSmsAsync(request);
-
             Assert.Equal("1", response.MessageCount);
             Assert.Equal("447700900000", response.Messages[0].To);
             Assert.Equal("0A0000000123ABCD1", response.Messages[0].MessageId);
@@ -114,6 +89,25 @@ namespace Vonage.Test.Unit
             Assert.Equal("3.14159265", response.Messages[0].RemainingBalance);
             Assert.Equal("12345", response.Messages[0].Network);
             Assert.Equal("customer1234", response.Messages[0].AccountRef);
+        }
+
+        [Fact]
+        public void SendSmsBadResponse()
+        {
+            var expectedResponse = GetExpectedJson();
+            var expectedUri = $"{RestUrl}/sms/json";
+            var expectedRequestContent =
+                $"from=AcmeInc&to=447700900000&text={HttpUtility.UrlEncode("Hello World!")}&api_key={ApiKey}&api_secret={ApiSecret}&";
+            Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var client = new VonageClient(Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret));
+            var exception = Assert.Throws<VonageSmsResponseException>(() =>
+                client.SmsClient.SendAnSms(new SendSmsRequest
+                    {From = "AcmeInc", To = "447700900000", Text = "Hello World!"}));
+            Assert.NotNull(exception);
+            Assert.Equal(
+                $"SMS Request Failed with status: {exception.Response.Messages[0].Status} and error message: {exception.Response.Messages[0].ErrorText}",
+                exception.Message);
+            Assert.Equal(SmsStatusCode.InvalidCredentials, exception.Response.Messages[0].StatusCode);
         }
 
         [Fact]
@@ -134,10 +128,12 @@ namespace Vonage.Test.Unit
                   ]
                 }";
             var expectedUri = $"{RestUrl}/sms/json";
-            var expectedRequestContent = $"from=AcmeInc&to=447700900000&text={HttpUtility.UrlEncode("Hello World!")}&api_key={ApiKey}&api_secret={ApiSecret}&";
+            var expectedRequestContent =
+                $"from=AcmeInc&to=447700900000&text={HttpUtility.UrlEncode("Hello World!")}&api_key={ApiKey}&api_secret={ApiSecret}&";
             Setup(expectedUri, expectedResponse, expectedRequestContent);
-            var client = new VonageClient(Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret));
-            var response = client.SmsClient.SendAnSms(new SendSmsRequest { From = "AcmeInc", To = "447700900000", Text = "Hello World!" });
+            var client = new VonageClient(Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret));
+            var response = client.SmsClient.SendAnSms(new SendSmsRequest
+                {From = "AcmeInc", To = "447700900000", Text = "Hello World!"});
             Assert.Equal("1", response.MessageCount);
             Assert.Equal("447700900000", response.Messages[0].To);
             Assert.Equal("0A0000000123ABCD1", response.Messages[0].MessageId);
@@ -166,9 +162,10 @@ namespace Vonage.Test.Unit
                   ]
                 }";
             var expectedUri = $"{RestUrl}/sms/json";
-            var expectedRequestContent = $"from=AcmeInc&to=447700900000&text={HttpUtility.UrlEncode("Hello World!")}&type=text&api_key={ApiKey}&api_secret={ApiSecret}&";
+            var expectedRequestContent =
+                $"from=AcmeInc&to=447700900000&text={HttpUtility.UrlEncode("Hello World!")}&type=text&api_key={ApiKey}&api_secret={ApiSecret}&";
             Setup(expectedUri, expectedResponse, expectedRequestContent);
-            var client = new VonageClient(Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret));
+            var client = new VonageClient(Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret));
             var response = client.SmsClient.SendAnSms("AcmeInc", "447700900000", "Hello World!");
             Assert.Equal("1", response.MessageCount);
             Assert.Equal("447700900000", response.Messages[0].To);
@@ -185,9 +182,10 @@ namespace Vonage.Test.Unit
         {
             var expectedResponse = GetExpectedJson();
             var expectedUri = $"{RestUrl}/sms/json";
-            var expectedRequestContent = $"from=AcmeInc&to=447700900000&text={HttpUtility.UrlEncode("Hello World!")}&type=text&api_key={ApiKey}&api_secret={ApiSecret}&";
+            var expectedRequestContent =
+                $"from=AcmeInc&to=447700900000&text={HttpUtility.UrlEncode("Hello World!")}&type=text&api_key={ApiKey}&api_secret={ApiSecret}&";
             Setup(expectedUri, expectedResponse, expectedRequestContent);
-            var client = new VonageClient(Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret));
+            var client = new VonageClient(Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret));
             var response = await client.SmsClient.SendAnSmsAsync("AcmeInc", "447700900000", "Hello World!");
             Assert.Equal("1", response.MessageCount);
             Assert.Equal("447700900000", response.Messages[0].To);
@@ -217,10 +215,12 @@ namespace Vonage.Test.Unit
                   ]
                 }";
             var expectedUri = $"{RestUrl}/sms/json";
-            var expectedRequestContent = $"from=AcmeInc&to=447700900000&text={HttpUtility.UrlEncode("こんにちは世界")}&api_key={ApiKey}&api_secret={ApiSecret}&";
+            var expectedRequestContent =
+                $"from=AcmeInc&to=447700900000&text={HttpUtility.UrlEncode("こんにちは世界")}&api_key={ApiKey}&api_secret={ApiSecret}&";
             Setup(expectedUri, expectedResponse, expectedRequestContent);
-            var client = new VonageClient(Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret));
-            var response = client.SmsClient.SendAnSms(new SendSmsRequest { From = "AcmeInc", To = "447700900000", Text = "こんにちは世界" });
+            var client = new VonageClient(Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret));
+            var response = client.SmsClient.SendAnSms(new SendSmsRequest
+                {From = "AcmeInc", To = "447700900000", Text = "こんにちは世界"});
             Assert.Equal("1", response.MessageCount);
             Assert.Equal("447700900000", response.Messages[0].To);
             Assert.Equal("0A0000000123ABCD1", response.Messages[0].MessageId);
@@ -231,55 +231,48 @@ namespace Vonage.Test.Unit
             Assert.Equal("customer1234", response.Messages[0].AccountRef);
         }
 
-        [Fact]
-        public void SendSmsBadResponse()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SendSmsWithAllPropertiesSet(bool passCreds)
         {
             var expectedResponse = GetExpectedJson();
             var expectedUri = $"{RestUrl}/sms/json";
-            var expectedRequestContent = $"from=AcmeInc&to=447700900000&text={HttpUtility.UrlEncode("Hello World!")}&api_key={ApiKey}&api_secret={ApiSecret}&";
+            var expectedRequestContent = $"from=AcmeInc&to=447700900000&text={HttpUtility.UrlEncode("Hello World!")}" +
+                                         $"&ttl=900000&status-report-req=true&callback={HttpUtility.UrlEncode("https://example.com/sms-dlr")}&message-class=0" +
+                                         "&type=text&body=638265253311&udh=06050415811581&protocol-id=127" +
+                                         $"&client-ref=my-personal-reference&account-ref=customer1234&entity-id=testEntity&content-id=testcontent&api_key={ApiKey}&api_secret={ApiSecret}&";
+            var request = new SendSmsRequest
+            {
+                AccountRef = "customer1234",
+                Body = "638265253311",
+                Callback = "https://example.com/sms-dlr",
+                ClientRef = "my-personal-reference",
+                From = "AcmeInc",
+                To = "447700900000",
+                MessageClass = 0,
+                ProtocolId = 127,
+                StatusReportReq = true,
+                Text = "Hello World!",
+                Ttl = 900000,
+                Type = SmsType.Text,
+                Udh = "06050415811581",
+                ContentId = "testcontent",
+                EntityId = "testEntity"
+            };
+            var creds = Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
             Setup(expectedUri, expectedResponse, expectedRequestContent);
-            var client = new VonageClient(Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret));
-
-            var exception = Assert.Throws<VonageSmsResponseException>(() =>
-                client.SmsClient.SendAnSms(new SendSmsRequest { From = "AcmeInc", To = "447700900000", Text = "Hello World!" }));
-
-            Assert.NotNull(exception);
-            Assert.Equal($"SMS Request Failed with status: {exception.Response.Messages[0].Status} and error message: {exception.Response.Messages[0].ErrorText}", exception.Message);
-            Assert.Equal(SmsStatusCode.InvalidCredentials, exception.Response.Messages[0].StatusCode);
-        }
-
-        [Fact]
-        public async Task SendSmsAsyncBadResponse()
-        {
-            var expectedResponse = GetExpectedJson();
-            var expectedUri = $"{RestUrl}/sms/json";
-            var expectedRequestContent = $"from=AcmeInc&to=447700900000&text={HttpUtility.UrlEncode("Hello World!")}&api_key={ApiKey}&api_secret={ApiSecret}&";
-            Setup(expectedUri, expectedResponse, expectedRequestContent);
-            var client = new VonageClient(Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret));
-
-            var exception = await Assert.ThrowsAsync<VonageSmsResponseException>(async () =>
-                await client.SmsClient.SendAnSmsAsync(new SendSmsRequest { From = "AcmeInc", To = "447700900000", Text = "Hello World!" }));
-
-            Assert.NotNull(exception);
-            Assert.Equal($"SMS Request Failed with status: {exception.Response.Messages[0].Status} and error message: {exception.Response.Messages[0].ErrorText}", exception.Message);
-            Assert.Equal(SmsStatusCode.InvalidCredentials, exception.Response.Messages[0].StatusCode);
-        }
-
-        [Fact]
-        public void NullMessagesResponse()
-        {
-            var expectedResponse = @"";
-            var expectedUri = $"{RestUrl}/sms/json";
-            var expectedRequestContent = $"from=AcmeInc&to=447700900000&text={HttpUtility.UrlEncode("Hello World!")}&api_key={ApiKey}&api_secret={ApiSecret}&";
-
-            Setup(expectedUri, expectedResponse, expectedRequestContent);
-            var client = new VonageClient(Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret));
-
-            var exception = Assert.Throws<VonageSmsResponseException>(() =>
-                client.SmsClient.SendAnSms(new SendSmsRequest { From = "AcmeInc", To = "447700900000", Text = "Hello World!" }));
-
-            Assert.NotNull(exception);
-            Assert.Equal($"Encountered an Empty SMS response", exception.Message);
+            var client = new VonageClient(creds);
+            var response = passCreds
+                ? client.SmsClient.SendAnSms(request, creds)
+                : client.SmsClient.SendAnSms(request);
+            Assert.Equal("1", response.MessageCount);
+            Assert.Equal("447700900000", response.Messages[0].To);
+            Assert.Equal("0A0000000123ABCD1", response.Messages[0].MessageId);
+            Assert.Equal("0", response.Messages[0].Status);
+            Assert.Equal("3.14159265", response.Messages[0].RemainingBalance);
+            Assert.Equal("12345", response.Messages[0].Network);
+            Assert.Equal("customer1234", response.Messages[0].AccountRef);
         }
 
         [Fact]
@@ -302,6 +295,43 @@ namespace Vonage.Test.Unit
                   ""client-ref"": ""steve""
                 }";
             var dlr = JsonConvert.DeserializeObject<DeliveryReceipt>(jsonFromNDP);
+            Assert.Equal("447700900000", dlr.Msisdn);
+            Assert.Equal("AcmeInc", dlr.To);
+            Assert.Equal("12345", dlr.NetworkCode);
+            Assert.Equal("0A0000001234567B", dlr.MessageId);
+            Assert.Equal("0.03330000", dlr.Price);
+            Assert.Equal(DlrStatus.delivered, dlr.Status);
+            Assert.Equal("2001011400", dlr.Scts);
+            Assert.Equal("0", dlr.ErrorCode);
+            Assert.Equal("abcd1234", dlr.ApiKey);
+            Assert.Equal("2020-01-01T12:00:00.000+00:00", dlr.MessageTimestamp);
+            Assert.True(1582650446 == dlr.Timestamp);
+            Assert.Equal("ec11dd3e-1e7f-4db5-9467-82b02cd223b9", dlr.Nonce);
+            Assert.Equal("1A20E4E2069B609FDA6CECA9DE18D5CAFE99720DDB628BD6BE8B19942A336E1C", dlr.Sig);
+            Assert.Equal("steve", dlr.ClientRef);
+        }
+
+        [Fact]
+        public void TestDlrStructCamelCaseIgnore()
+        {
+            var jsonFromNDP = @"{
+                  ""msisdn"": ""447700900000"",
+                  ""to"": ""AcmeInc"",
+                  ""network-code"": ""12345"",
+                  ""messageId"": ""0A0000001234567B"",
+                  ""price"": ""0.03330000"",
+                  ""status"": ""delivered"",
+                  ""scts"": ""2001011400"",
+                  ""err-code"": ""0"",
+                  ""api-key"": ""abcd1234"",
+                  ""message-timestamp"": ""2020-01-01T12:00:00.000+00:00"",
+                  ""timestamp"": 1582650446,
+                  ""nonce"": ""ec11dd3e-1e7f-4db5-9467-82b02cd223b9"",
+                  ""sig"": ""1A20E4E2069B609FDA6CECA9DE18D5CAFE99720DDB628BD6BE8B19942A336E1C"",
+                  ""client-ref"": ""steve""
+                }";
+            var dlr = JsonConvert.DeserializeObject<DeliveryReceipt>(jsonFromNDP,
+                VonageSerialization.SerializerSettings);
             Assert.Equal("447700900000", dlr.Msisdn);
             Assert.Equal("AcmeInc", dlr.To);
             Assert.Equal("12345", dlr.NetworkCode);
@@ -413,10 +443,10 @@ namespace Vonage.Test.Unit
             var TestSigningSecret = "Y6dI3wtDP8myVH5tnDoIaTxEvAJhgDVCczBa1mHniEqsdlnnebg";
             var json = JsonConvert.SerializeObject(inboundSmsShell, VonageSerialization.SerializerSettings);
             var dict = JsonConvert.DeserializeObject<Dictionary<string, string>>(json);
-
-            inboundSmsShell.Sig = Cryptography.SmsSignatureGenerator.GenerateSignature(InboundSms.ConstructSignatureStringFromDictionary(dict), TestSigningSecret, Cryptography.SmsSignatureGenerator.Method.md5);
-
-            Assert.True(inboundSmsShell.ValidateSignature(TestSigningSecret, Cryptography.SmsSignatureGenerator.Method.md5));
+            inboundSmsShell.Sig = SmsSignatureGenerator.GenerateSignature(
+                InboundSms.ConstructSignatureStringFromDictionary(dict), TestSigningSecret,
+                SmsSignatureGenerator.Method.md5);
+            Assert.True(inboundSmsShell.ValidateSignature(TestSigningSecret, SmsSignatureGenerator.Method.md5));
         }
 
         [Fact]
@@ -439,8 +469,10 @@ namespace Vonage.Test.Unit
             var TestSigningSecret = "17c6ecf583ef7da515bcfc655426970c";
             var json = JsonConvert.SerializeObject(inboundSmsShell, VonageSerialization.SerializerSettings);
             var dict = JsonConvert.DeserializeObject<Dictionary<string, string>>(json);
-            inboundSmsShell.Sig = Cryptography.SmsSignatureGenerator.GenerateSignature(InboundSms.ConstructSignatureStringFromDictionary(dict), TestSigningSecret, Cryptography.SmsSignatureGenerator.Method.md5hash);
-            Assert.True(inboundSmsShell.ValidateSignature(TestSigningSecret, Cryptography.SmsSignatureGenerator.Method.md5hash));
+            inboundSmsShell.Sig = SmsSignatureGenerator.GenerateSignature(
+                InboundSms.ConstructSignatureStringFromDictionary(dict), TestSigningSecret,
+                SmsSignatureGenerator.Method.md5hash);
+            Assert.True(inboundSmsShell.ValidateSignature(TestSigningSecret, SmsSignatureGenerator.Method.md5hash));
         }
 
         [Fact]
@@ -463,8 +495,10 @@ namespace Vonage.Test.Unit
             var TestSigningSecret = "B462F6EF6C0D161EEA214C5D37FC0E1D31C0BC08";
             var json = JsonConvert.SerializeObject(inboundSmsShell, VonageSerialization.SerializerSettings);
             var dict = JsonConvert.DeserializeObject<Dictionary<string, string>>(json);
-            inboundSmsShell.Sig = Cryptography.SmsSignatureGenerator.GenerateSignature(InboundSms.ConstructSignatureStringFromDictionary(dict), TestSigningSecret, Cryptography.SmsSignatureGenerator.Method.sha1);
-            Assert.True(inboundSmsShell.ValidateSignature(TestSigningSecret, Cryptography.SmsSignatureGenerator.Method.sha1));
+            inboundSmsShell.Sig = SmsSignatureGenerator.GenerateSignature(
+                InboundSms.ConstructSignatureStringFromDictionary(dict), TestSigningSecret,
+                SmsSignatureGenerator.Method.sha1);
+            Assert.True(inboundSmsShell.ValidateSignature(TestSigningSecret, SmsSignatureGenerator.Method.sha1));
         }
 
         [Fact]
@@ -487,8 +521,10 @@ namespace Vonage.Test.Unit
             var TestSigningSecret = "D1EA9F0A89C2C62DD89FFE9585E8CD27163DA47458D353EC7084376BADA72817";
             var json = JsonConvert.SerializeObject(inboundSmsShell, VonageSerialization.SerializerSettings);
             var dict = JsonConvert.DeserializeObject<Dictionary<string, string>>(json);
-            inboundSmsShell.Sig = Cryptography.SmsSignatureGenerator.GenerateSignature(InboundSms.ConstructSignatureStringFromDictionary(dict), TestSigningSecret, Cryptography.SmsSignatureGenerator.Method.sha256);
-            Assert.True(inboundSmsShell.ValidateSignature(TestSigningSecret, Cryptography.SmsSignatureGenerator.Method.sha256));
+            inboundSmsShell.Sig = SmsSignatureGenerator.GenerateSignature(
+                InboundSms.ConstructSignatureStringFromDictionary(dict), TestSigningSecret,
+                SmsSignatureGenerator.Method.sha256);
+            Assert.True(inboundSmsShell.ValidateSignature(TestSigningSecret, SmsSignatureGenerator.Method.sha256));
         }
 
         [Fact]
@@ -508,50 +544,14 @@ namespace Vonage.Test.Unit
                 Concat = true,
                 ConcatRef = "3",
             };
-            var TestSigningSecret = "A8E2BB164A894DB7BC7807D7E5A09003B3F25F185D5202F2616EA8D285AD5E8248D50827091B302D07FC967125108339B155938DA45B27C79E45A83CD4914B7C";
+            var TestSigningSecret =
+                "A8E2BB164A894DB7BC7807D7E5A09003B3F25F185D5202F2616EA8D285AD5E8248D50827091B302D07FC967125108339B155938DA45B27C79E45A83CD4914B7C";
             var json = JsonConvert.SerializeObject(inboundSmsShell, VonageSerialization.SerializerSettings);
             var dict = JsonConvert.DeserializeObject<Dictionary<string, string>>(json);
-            inboundSmsShell.Sig = Cryptography.SmsSignatureGenerator.GenerateSignature(InboundSms.ConstructSignatureStringFromDictionary(dict), TestSigningSecret, Cryptography.SmsSignatureGenerator.Method.sha512);
-            Assert.True(inboundSmsShell.ValidateSignature(TestSigningSecret, Cryptography.SmsSignatureGenerator.Method.sha512));
-        }
-
-
-        [Fact]
-        public void TestDlrStructCamelCaseIgnore()
-        {
-            var jsonFromNDP = @"{
-                  ""msisdn"": ""447700900000"",
-                  ""to"": ""AcmeInc"",
-                  ""network-code"": ""12345"",
-                  ""messageId"": ""0A0000001234567B"",
-                  ""price"": ""0.03330000"",
-                  ""status"": ""delivered"",
-                  ""scts"": ""2001011400"",
-                  ""err-code"": ""0"",
-                  ""api-key"": ""abcd1234"",
-                  ""message-timestamp"": ""2020-01-01T12:00:00.000+00:00"",
-                  ""timestamp"": 1582650446,
-                  ""nonce"": ""ec11dd3e-1e7f-4db5-9467-82b02cd223b9"",
-                  ""sig"": ""1A20E4E2069B609FDA6CECA9DE18D5CAFE99720DDB628BD6BE8B19942A336E1C"",
-                  ""client-ref"": ""steve""
-                }";
-
-            var dlr = JsonConvert.DeserializeObject<DeliveryReceipt>(jsonFromNDP, VonageSerialization.SerializerSettings);
-            Assert.Equal("447700900000", dlr.Msisdn);
-            Assert.Equal("AcmeInc", dlr.To);
-            Assert.Equal("12345", dlr.NetworkCode);
-            Assert.Equal("0A0000001234567B", dlr.MessageId);
-            Assert.Equal("0.03330000", dlr.Price);
-            Assert.Equal(DlrStatus.delivered, dlr.Status);
-            Assert.Equal("2001011400", dlr.Scts);
-            Assert.Equal("0", dlr.ErrorCode);
-            Assert.Equal("abcd1234", dlr.ApiKey);
-            Assert.Equal("2020-01-01T12:00:00.000+00:00", dlr.MessageTimestamp);
-            Assert.True(1582650446 == dlr.Timestamp);
-            Assert.Equal("ec11dd3e-1e7f-4db5-9467-82b02cd223b9", dlr.Nonce);
-            Assert.Equal("1A20E4E2069B609FDA6CECA9DE18D5CAFE99720DDB628BD6BE8B19942A336E1C", dlr.Sig);
-            Assert.Equal("steve", dlr.ClientRef);
+            inboundSmsShell.Sig = SmsSignatureGenerator.GenerateSignature(
+                InboundSms.ConstructSignatureStringFromDictionary(dict), TestSigningSecret,
+                SmsSignatureGenerator.Method.sha512);
+            Assert.True(inboundSmsShell.ValidateSignature(TestSigningSecret, SmsSignatureGenerator.Method.sha512));
         }
     }
 }
-

--- a/Vonage/Messaging/SendSmsRequest.cs
+++ b/Vonage/Messaging/SendSmsRequest.cs
@@ -6,6 +6,46 @@ namespace Vonage.Messaging
     public class SendSmsRequest
     {
         /// <summary>
+        /// An optional string used to identify separate accounts using the SMS endpoint for billing purposes. 
+        /// To use this feature, please email support@nexmo.com
+        /// </summary>
+        [JsonProperty("account-ref")]
+        public string AccountRef { get; set; }
+
+        /// <summary>
+        /// Hex encoded binary data. Depends on type parameter having the value binary.
+        /// </summary>
+        [JsonProperty("body")]
+        public string Body { get; set; }
+
+        /// <summary>
+        /// The webhook endpoint the delivery receipt for this sms is sent to. 
+        /// This parameter overrides the webhook endpoint you set in Dashboard.
+        /// </summary>
+        [JsonProperty("callback")]
+        public string Callback { get; set; }
+
+        /// <summary>
+        /// You can optionally include your own reference of up to 40 characters.
+        /// </summary>
+        [JsonProperty("client-ref")]
+        public string ClientRef { get; set; }
+
+        /// <summary>
+        /// A string parameter that satisfies regulatory requirements when sending an SMS to specific countries.
+        /// For more information please refer to the <see href="https://help.nexmo.com/hc/en-us/articles/115011781468">Country-Specific Outbound SMS Features</see>
+        /// </summary>
+        [JsonProperty("content-id")]
+        public string ContentId { get; set; }
+
+        /// <summary>
+        /// A string parameter that satisfies regulatory requirements when sending an SMS to specific countries.
+        /// For more information please refer to the <see href="https://help.nexmo.com/hc/en-us/articles/115011781468">Country-Specific Outbound SMS Features</see>
+        /// </summary>
+        [JsonProperty("entity-id")]
+        public string EntityId { get; set; }
+
+        /// <summary>
         /// The name or number the message should be sent from. 
         /// Alphanumeric senderID's are not supported in all countries, 
         /// see Global Messaging for more details. If alphanumeric, 
@@ -15,10 +55,23 @@ namespace Vonage.Messaging
         public string From { get; set; }
 
         /// <summary>
-        /// The number that the message should be sent to. Numbers are specified in E.164 format.
+        ///  The Data Coding Scheme value of the message
+        ///  Must be one of: 0, 1, 2 or 3
         /// </summary>
-        [JsonProperty("to")]
-        public string To { get; set; }
+        [JsonProperty("message-class")]
+        public int? MessageClass { get; set; }
+
+        /// <summary>
+        /// The value of the protocol identifier to use. Ensure that the value is aligned with udh.
+        /// </summary>
+        [JsonProperty("protocol-id")]
+        public int? ProtocolId { get; set; }
+
+        /// <summary>
+        /// Boolean indicating if you like to receive a Delivery Receipt.
+        /// </summary>
+        [JsonProperty("status-report-req")]
+        public bool? StatusReportReq { get; set; }
 
         /// <summary>
         /// The body of the message being sent. If your message contains characters 
@@ -27,6 +80,12 @@ namespace Vonage.Messaging
         /// </summary>
         [JsonProperty("text")]
         public string Text { get; set; }
+
+        /// <summary>
+        /// The number that the message should be sent to. Numbers are specified in E.164 format.
+        /// </summary>
+        [JsonProperty("to")]
+        public string To { get; set; }
 
         /// <summary>
         /// The duration in milliseconds the delivery of an SMS will be attempted.
@@ -38,26 +97,6 @@ namespace Vonage.Messaging
         public int? Ttl { get; set; }
 
         /// <summary>
-        /// Boolean indicating if you like to receive a Delivery Receipt.
-        /// </summary>
-        [JsonProperty("status-report-req")]
-        public bool? StatusReportReq { get; set; }
-
-        /// <summary>
-        /// The webhook endpoint the delivery receipt for this sms is sent to. 
-        /// This parameter overrides the webhook endpoint you set in Dashboard.
-        /// </summary>
-        [JsonProperty("callback")]
-        public string Callback { get; set; }
-
-        /// <summary>
-        ///  The Data Coding Scheme value of the message
-        ///  Must be one of: 0, 1, 2 or 3
-        /// </summary>
-        [JsonProperty("message-class")]
-        public int? MessageClass { get; set; }
-
-        /// <summary>
         /// The format of the message body         
         /// </summary>
         [JsonProperty("type")]
@@ -65,78 +104,9 @@ namespace Vonage.Messaging
         public SmsType? Type { get; set; }
 
         /// <summary>
-        /// A business card in vCard format. Depends on type parameter having the value vcard.
-        /// </summary>
-        [JsonProperty("vcard")]
-        public string Vcard { get; set; }
-
-        /// <summary>
-        /// A calendar event in vCal format. Depends on type parameter having the value vcal.
-        /// </summary>
-        [JsonProperty("vcal")]
-        public string Vcal { get; set; }
-
-        /// <summary>
-        /// Hex encoded binary data. Depends on type parameter having the value binary.
-        /// </summary>
-        [JsonProperty("body")]
-        public string Body { get; set; }
-
-        /// <summary>
         /// Your custom Hex encoded User Data Header. Depends on type parameter having the value binary.
         /// </summary>
         [JsonProperty("udh")]
         public string Udh { get; set; }
-
-        /// <summary>
-        /// The value of the protocol identifier to use. Ensure that the value is aligned with udh.
-        /// </summary>
-        [JsonProperty("protocol-id")]
-        public int? ProtocolId { get; set; }
-
-        /// <summary>
-        /// The title for a wappush SMS. Depends on type parameter having the value wappush.
-        /// </summary>
-        [JsonProperty("title")]
-        public string Title { get; set; }
-
-        /// <summary>
-        /// The URL of your website. Depends on type parameter having the value wappush.
-        /// </summary>
-        [JsonProperty("url")]
-        public string Url { get; set; }
-
-        /// <summary>
-        /// The availability for an SMS in milliseconds. Depends on type parameter having the value wappush.
-        /// </summary>
-        [JsonProperty("validity")]
-        public string Validity { get; set; }
-
-        /// <summary>
-        /// You can optionally include your own reference of up to 40 characters.
-        /// </summary>
-        [JsonProperty("client-ref")]
-        public string ClientRef { get; set; }
-
-        /// <summary>
-        /// An optional string used to identify separate accounts using the SMS endpoint for billing purposes. 
-        /// To use this feature, please email support@nexmo.com
-        /// </summary>
-        [JsonProperty("account-ref")]
-        public string AccountRef { get; set; }
-
-        /// <summary>
-        /// A string parameter that satisfies regulatory requirements when sending an SMS to specific countries.
-        /// For more information please refer to the <see href="https://help.nexmo.com/hc/en-us/articles/115011781468">Country-Specific Outbound SMS Features</see>
-        /// </summary>
-        [JsonProperty("entity-id")]
-        public string EntityId { get; set; }
-
-        /// <summary>
-        /// A string parameter that satisfies regulatory requirements when sending an SMS to specific countries.
-        /// For more information please refer to the <see href="https://help.nexmo.com/hc/en-us/articles/115011781468">Country-Specific Outbound SMS Features</see>
-        /// </summary>
-        [JsonProperty("content-id")]
-        public string ContentId { get; set; }
     }
 }

--- a/Vonage/Messaging/SendSmsRequest.cs
+++ b/Vonage/Messaging/SendSmsRequest.cs
@@ -9,40 +9,40 @@ namespace Vonage.Messaging
         /// An optional string used to identify separate accounts using the SMS endpoint for billing purposes. 
         /// To use this feature, please email support@nexmo.com
         /// </summary>
-        [JsonProperty("account-ref")]
+        [JsonProperty("account-ref", Order = 12)]
         public string AccountRef { get; set; }
 
         /// <summary>
         /// Hex encoded binary data. Depends on type parameter having the value binary.
         /// </summary>
-        [JsonProperty("body")]
+        [JsonProperty("body", Order = 8)]
         public string Body { get; set; }
 
         /// <summary>
         /// The webhook endpoint the delivery receipt for this sms is sent to. 
         /// This parameter overrides the webhook endpoint you set in Dashboard.
         /// </summary>
-        [JsonProperty("callback")]
+        [JsonProperty("callback", Order = 5)]
         public string Callback { get; set; }
 
         /// <summary>
         /// You can optionally include your own reference of up to 40 characters.
         /// </summary>
-        [JsonProperty("client-ref")]
+        [JsonProperty("client-ref", Order = 11)]
         public string ClientRef { get; set; }
 
         /// <summary>
         /// A string parameter that satisfies regulatory requirements when sending an SMS to specific countries.
         /// For more information please refer to the <see href="https://help.nexmo.com/hc/en-us/articles/115011781468">Country-Specific Outbound SMS Features</see>
         /// </summary>
-        [JsonProperty("content-id")]
+        [JsonProperty("content-id", Order = 14)]
         public string ContentId { get; set; }
 
         /// <summary>
         /// A string parameter that satisfies regulatory requirements when sending an SMS to specific countries.
         /// For more information please refer to the <see href="https://help.nexmo.com/hc/en-us/articles/115011781468">Country-Specific Outbound SMS Features</see>
         /// </summary>
-        [JsonProperty("entity-id")]
+        [JsonProperty("entity-id", Order = 13)]
         public string EntityId { get; set; }
 
         /// <summary>
@@ -51,26 +51,26 @@ namespace Vonage.Messaging
         /// see Global Messaging for more details. If alphanumeric, 
         /// spaces will be ignored. Numbers are specified in E.164 format.
         /// </summary>
-        [JsonProperty("from")]
+        [JsonProperty("from", Order = 0)]
         public string From { get; set; }
 
         /// <summary>
         ///  The Data Coding Scheme value of the message
         ///  Must be one of: 0, 1, 2 or 3
         /// </summary>
-        [JsonProperty("message-class")]
+        [JsonProperty("message-class", Order = 6)]
         public int? MessageClass { get; set; }
 
         /// <summary>
         /// The value of the protocol identifier to use. Ensure that the value is aligned with udh.
         /// </summary>
-        [JsonProperty("protocol-id")]
+        [JsonProperty("protocol-id", Order = 10)]
         public int? ProtocolId { get; set; }
 
         /// <summary>
         /// Boolean indicating if you like to receive a Delivery Receipt.
         /// </summary>
-        [JsonProperty("status-report-req")]
+        [JsonProperty("status-report-req", Order = 4)]
         public bool? StatusReportReq { get; set; }
 
         /// <summary>
@@ -78,13 +78,13 @@ namespace Vonage.Messaging
         /// that can be encoded according to the GSM Standard and Extended tables then you can set the type to text. 
         /// If your message contains characters outside this range, then you will need to set the type to unicode.
         /// </summary>
-        [JsonProperty("text")]
+        [JsonProperty("text", Order = 2)]
         public string Text { get; set; }
 
         /// <summary>
         /// The number that the message should be sent to. Numbers are specified in E.164 format.
         /// </summary>
-        [JsonProperty("to")]
+        [JsonProperty("to", Order = 1)]
         public string To { get; set; }
 
         /// <summary>
@@ -93,20 +93,20 @@ namespace Vonage.Messaging
         /// however the maximum effective value depends on the operator and is typically 24 - 48 hours.
         /// We recommend this value should be kept at its default or at least 30 minutes.
         /// </summary>
-        [JsonProperty("ttl")]
+        [JsonProperty("ttl", Order = 3)]
         public int? Ttl { get; set; }
 
         /// <summary>
         /// The format of the message body         
         /// </summary>
-        [JsonProperty("type")]
+        [JsonProperty("type", Order = 7)]
         [JsonConverter(typeof(StringEnumConverter))]
         public SmsType? Type { get; set; }
 
         /// <summary>
         /// Your custom Hex encoded User Data Header. Depends on type parameter having the value binary.
         /// </summary>
-        [JsonProperty("udh")]
+        [JsonProperty("udh", Order = 9)]
         public string Udh { get; set; }
     }
 }

--- a/Vonage/Messaging/SmsType.cs
+++ b/Vonage/Messaging/SmsType.cs
@@ -2,24 +2,27 @@
 
 namespace Vonage.Messaging
 {
+    /// <summary>
+    /// Represents the type of message.
+    /// </summary>
     public enum SmsType
     {
+        /// <summary>
+        /// 
+        /// </summary>
         [EnumMember(Value = "text")]
         Text = 1,
         
+        /// <summary>
+        /// 
+        /// </summary>
         [EnumMember(Value = "binary")]
         Binary = 2,
         
-        [EnumMember(Value = "wappush")]
-        Wappush = 3,
-        
+        /// <summary>
+        /// 
+        /// </summary>
         [EnumMember(Value = "unicode")]
         Unicode = 4,
-        
-        [EnumMember(Value = "vcal")]
-        VCal = 5,
-        
-        [EnumMember(Value = "vcar")]
-        VCar = 6
     }
 }


### PR DESCRIPTION
These enum values weren't used in any test. Therefore, no further change is required