### PR TITLE
[DEVX-7128] NumbersAPI update

### DIFF
--- a/Vonage.Test.Unit/NumbersTests.cs
+++ b/Vonage.Test.Unit/NumbersTests.cs
@@ -1,21 +1,207 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Web;
+﻿using System.Web;
 using Vonage.Numbers;
+using Vonage.Request;
 using Xunit;
+
 namespace Vonage.Test.Unit
 {
     public class NumbersTests : TestBase
     {
         [Theory]
-        [InlineData(true,true)]
-        [InlineData(false,false)]
-        public void TestSearchNumbers(bool passCreds, bool kitchenSink)
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void TestBuyNumber(bool passCredentials, bool kitchenSink)
         {
-            var expetedResponse = @"{
+            var expectedResponse = @"{
+              ""error-code"": ""200"",
+              ""error-code-label"": ""success""
+            }";
+            var expectedUri = $"{this.RestUrl}/number/buy?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
+            string expectedRequestContent;
+            NumberTransactionRequest request;
+            if (kitchenSink)
+            {
+                expectedRequestContent = "country=GB&msisdn=447700900000&target_api_key=12345&";
+                request = new NumberTransactionRequest
+                    {Country = "GB", Msisdn = "447700900000", TargetApiKey = "12345"};
+            }
+            else
+            {
+                expectedRequestContent = "country=GB&msisdn=447700900000&";
+                request = new NumberTransactionRequest {Country = "GB", Msisdn = "447700900000"};
+            }
+
+            this.Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var credentials = Credentials.FromApiKeyAndSecret(this.ApiKey, this.ApiSecret);
+            var client = new VonageClient(credentials);
+            NumberTransactionResponse response;
+            if (passCredentials)
+            {
+                response = client.NumbersClient.BuyANumber(request, credentials);
+            }
+            else
+            {
+                response = client.NumbersClient.BuyANumber(request);
+            }
+
+            Assert.Equal("200", response.ErrorCode);
+            Assert.Equal("success", response.ErrorCodeLabel);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public async void TestBuyNumberAsync(bool passCredentials, bool kitchenSink)
+        {
+            var expectedResponse = @"{
+              ""error-code"": ""200"",
+              ""error-code-label"": ""success""
+            }";
+            var expectedUri = $"{this.RestUrl}/number/buy?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
+            string expectedRequestContent;
+            NumberTransactionRequest request;
+            if (kitchenSink)
+            {
+                expectedRequestContent = "country=GB&msisdn=447700900000&target_api_key=12345&";
+                request = new NumberTransactionRequest
+                    {Country = "GB", Msisdn = "447700900000", TargetApiKey = "12345"};
+            }
+            else
+            {
+                expectedRequestContent = "country=GB&msisdn=447700900000&";
+                request = new NumberTransactionRequest {Country = "GB", Msisdn = "447700900000"};
+            }
+
+            this.Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var credentials = Credentials.FromApiKeyAndSecret(this.ApiKey, this.ApiSecret);
+            var client = new VonageClient(credentials);
+            NumberTransactionResponse response;
+            if (passCredentials)
+            {
+                response = await client.NumbersClient.BuyANumberAsync(request, credentials);
+            }
+            else
+            {
+                response = await client.NumbersClient.BuyANumberAsync(request);
+            }
+
+            Assert.Equal("200", response.ErrorCode);
+            Assert.Equal("success", response.ErrorCodeLabel);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void TestCancelNumber(bool passCredentials, bool kitchenSink)
+        {
+            var expectedResponse = @"{
+              ""error-code"": ""200"",
+              ""error-code-label"": ""success""
+            }";
+            var expectedUri = $"{this.RestUrl}/number/cancel?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
+            string expectedRequestContent;
+            NumberTransactionRequest request;
+            if (kitchenSink)
+            {
+                expectedRequestContent = "country=GB&msisdn=447700900000&target_api_key=12345&";
+                request = new NumberTransactionRequest
+                    {Country = "GB", Msisdn = "447700900000", TargetApiKey = "12345"};
+            }
+            else
+            {
+                expectedRequestContent = "country=GB&msisdn=447700900000&";
+                request = new NumberTransactionRequest {Country = "GB", Msisdn = "447700900000"};
+            }
+
+            this.Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var credentials = Credentials.FromApiKeyAndSecret(this.ApiKey, this.ApiSecret);
+            var client = new VonageClient(credentials);
+            NumberTransactionResponse response;
+            if (passCredentials)
+            {
+                response = client.NumbersClient.CancelANumber(request, credentials);
+            }
+            else
+            {
+                response = client.NumbersClient.CancelANumber(request);
+            }
+
+            Assert.Equal("200", response.ErrorCode);
+            Assert.Equal("success", response.ErrorCodeLabel);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public async void TestCancelNumberAsync(bool passCredentials, bool kitchenSink)
+        {
+            const string expectedResponse = @"{
+              ""error-code"": ""200"",
+              ""error-code-label"": ""success""
+            }";
+            var expectedUri = $"{this.RestUrl}/number/cancel?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
+            string expectedRequestContent;
+            NumberTransactionRequest request;
+            if (kitchenSink)
+            {
+                expectedRequestContent = "country=GB&msisdn=447700900000&target_api_key=12345&";
+                request = new NumberTransactionRequest
+                    {Country = "GB", Msisdn = "447700900000", TargetApiKey = "12345"};
+            }
+            else
+            {
+                expectedRequestContent = "country=GB&msisdn=447700900000&";
+                request = new NumberTransactionRequest {Country = "GB", Msisdn = "447700900000"};
+            }
+
+            this.Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var credentials = Credentials.FromApiKeyAndSecret(this.ApiKey, this.ApiSecret);
+            var client = new VonageClient(credentials);
+            NumberTransactionResponse response;
+            if (passCredentials)
+            {
+                response = await client.NumbersClient.CancelANumberAsync(request, credentials);
+            }
+            else
+            {
+                response = await client.NumbersClient.CancelANumberAsync(request);
+            }
+
+            Assert.Equal("200", response.ErrorCode);
+            Assert.Equal("success", response.ErrorCodeLabel);
+        }
+
+        [Fact]
+        public void TestFailedPurchase()
+        {
+            const string expectedResponse = @"{
+              ""error-code"": ""401"",
+              ""error-code-label"": ""authentifcation failed""
+            }";
+            var expectedUri = $"{this.RestUrl}/number/buy?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
+            var expectedRequestContent = "country=GB&msisdn=447700900000&";
+            this.Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var request = new NumberTransactionRequest {Country = "GB", Msisdn = "447700900000"};
+            var credentials = Credentials.FromApiKeyAndSecret(this.ApiKey, this.ApiSecret);
+            var client = new VonageClient(credentials);
+            try
+            {
+                client.NumbersClient.BuyANumber(request);
+                Assert.True(false, "Failin because exception was not thrown");
+            }
+            catch (VonageNumberResponseException ex)
+            {
+                Assert.Equal("401", ex.Response.ErrorCode);
+                Assert.Equal("authentifcation failed", ex.Response.ErrorCodeLabel);
+            }
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void TestSearchNumbers(bool passCredentials, bool kitchenSink)
+        {
+            const string expectedResponse = @"{
               ""count"": 1234,
               ""numbers"": [
                 {
@@ -30,26 +216,31 @@ namespace Vonage.Test.Unit
                 }
               ]
             }";
-            var expectedUri = $"{RestUrl}/number/search";
+            var expectedUri = $"{this.RestUrl}/number/search";
             NumberSearchRequest request;
             if (kitchenSink)
             {
-                expectedUri += $"?country=GB&type=mobile-lvn&pattern=12345&search_pattern=1&features=SMS&size=10&index=1&api_key={ApiKey}&api_secret={ApiSecret}&";
-                request = new NumberSearchRequest { Country = "GB", Type = "mobile-lvn", Pattern = "12345", SearchPattern = SearchPattern.Contains, Features = "SMS", Size = 10, Index = 1 };
+                expectedUri +=
+                    $"?country=GB&type=mobile-lvn&pattern=12345&search_pattern=1&features=SMS&size=10&index=1&api_key={this.ApiKey}&api_secret={this.ApiSecret}&";
+                request = new NumberSearchRequest
+                {
+                    Country = "GB", Type = "mobile-lvn", Pattern = "12345", SearchPattern = SearchPattern.Contains,
+                    Features = "SMS", Size = 10, Index = 1,
+                };
             }
             else
             {
-                expectedUri += $"?country=GB&api_key={ApiKey}&api_secret={ApiSecret}&";
-                request = new NumberSearchRequest { Country = "GB" };
+                expectedUri += $"?country=GB&api_key={this.ApiKey}&api_secret={this.ApiSecret}&";
+                request = new NumberSearchRequest {Country = "GB"};
             }
-            Setup(expectedUri, expetedResponse);
-            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
-            var client = new VonageClient(creds);
 
+            this.Setup(expectedUri, expectedResponse);
+            var credentials = Credentials.FromApiKeyAndSecret(this.ApiKey, this.ApiSecret);
+            var client = new VonageClient(credentials);
             NumbersSearchResponse response;
-            if (passCreds)
+            if (passCredentials)
             {
-                response = client.NumbersClient.GetAvailableNumbers(request, creds);
+                response = client.NumbersClient.GetAvailableNumbers(request, credentials);
             }
             else
             {
@@ -69,9 +260,9 @@ namespace Vonage.Test.Unit
         [Theory]
         [InlineData(true, true)]
         [InlineData(false, false)]
-        public async void TestSearchNumbersAsync(bool passCreds, bool kitchenSink)
+        public async void TestSearchNumbersAsync(bool passCredentials, bool kitchenSink)
         {
-            var expetedResponse = @"{
+            const string expectedResponse = @"{
               ""count"": 1234,
               ""numbers"": [
                 {
@@ -86,26 +277,31 @@ namespace Vonage.Test.Unit
                 }
               ]
             }";
-            var expectedUri = $"{RestUrl}/number/search";
+            var expectedUri = $"{this.RestUrl}/number/search";
             NumberSearchRequest request;
             if (kitchenSink)
             {
-                expectedUri += $"?country=GB&type=mobile-lvn&pattern=12345&search_pattern=1&features=SMS&size=10&index=1&api_key={ApiKey}&api_secret={ApiSecret}&";
-                request = new NumberSearchRequest { Country = "GB", Type = "mobile-lvn", Pattern = "12345", SearchPattern = SearchPattern.Contains, Features = "SMS", Size = 10, Index = 1 };
+                expectedUri +=
+                    $"?country=GB&type=mobile-lvn&pattern=12345&search_pattern=1&features=SMS&size=10&index=1&api_key={this.ApiKey}&api_secret={this.ApiSecret}&";
+                request = new NumberSearchRequest
+                {
+                    Country = "GB", Type = "mobile-lvn", Pattern = "12345", SearchPattern = SearchPattern.Contains,
+                    Features = "SMS", Size = 10, Index = 1,
+                };
             }
             else
             {
-                expectedUri += $"?country=GB&api_key={ApiKey}&api_secret={ApiSecret}&";
-                request = new NumberSearchRequest { Country = "GB" };
+                expectedUri += $"?country=GB&api_key={this.ApiKey}&api_secret={this.ApiSecret}&";
+                request = new NumberSearchRequest {Country = "GB"};
             }
-            Setup(expectedUri, expetedResponse);
-            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
-            var client = new VonageClient(creds);
 
+            this.Setup(expectedUri, expectedResponse);
+            var credentials = Credentials.FromApiKeyAndSecret(this.ApiKey, this.ApiSecret);
+            var client = new VonageClient(credentials);
             NumbersSearchResponse response;
-            if (passCreds)
+            if (passCredentials)
             {
-                response = await client.NumbersClient.GetAvailableNumbersAsync(request, creds);
+                response = await client.NumbersClient.GetAvailableNumbersAsync(request, credentials);
             }
             else
             {
@@ -123,217 +319,47 @@ namespace Vonage.Test.Unit
         }
 
         [Theory]
-        [InlineData(true,true)]
-        [InlineData(false,false)]
-        public void TestBuyNumber(bool passCreds, bool kitchenSink)
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void TestUpdateNumber(bool passCredentials, bool kitchenSink)
         {
-            var expectedResponse = @"{
+            const string expectedResponse = @"{
               ""error-code"": ""200"",
               ""error-code-label"": ""success""
             }";
-            var expectedUri = $"{RestUrl}/number/buy?api_key={ApiKey}&api_secret={ApiSecret}";
+            var expectedUri = $"{this.RestUrl}/number/update?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
             string expectedRequestContent;
-            NumberTransactionRequest request;
-
-            if (kitchenSink)
-            {
-                expectedRequestContent = $"country=GB&msisdn=447700900000&target_api_key=12345&";
-                request = new NumberTransactionRequest { Country = "GB", Msisdn = "447700900000", TargetApiKey="12345" };
-            }
-            else
-            {
-                expectedRequestContent = $"country=GB&msisdn=447700900000&";
-                request = new NumberTransactionRequest { Country = "GB", Msisdn = "447700900000" };
-            }
-            
-            Setup(expectedUri, expectedResponse, expectedRequestContent);
-
-            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
-            var client = new VonageClient(creds);
-            NumberTransactionResponse response;
-            if (passCreds)
-            {
-                response = client.NumbersClient.BuyANumber(request, creds);
-            }
-            else
-            {
-                response = client.NumbersClient.BuyANumber(request);
-            }
-            
-            Assert.Equal("200",response.ErrorCode);
-            Assert.Equal("success", response.ErrorCodeLabel);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public async void TestBuyNumberAsync(bool passCreds, bool kitchenSink)
-        {
-            var expectedResponse = @"{
-              ""error-code"": ""200"",
-              ""error-code-label"": ""success""
-            }";
-            var expectedUri = $"{RestUrl}/number/buy";
-            string expectdRequestContent = $"country=GB&msisdn=447700900000&api_key={ApiKey}&api_secret={ApiSecret}&";
-            NumberTransactionRequest request;
-
-            if (kitchenSink)
-            {
-                expectdRequestContent = $"country=GB&msisdn=447700900000&target_api_key=12345&api_key={ApiKey}&api_secret={ApiSecret}&";
-                request = new NumberTransactionRequest { Country = "GB", Msisdn = "447700900000", TargetApiKey = "12345" };
-            }
-            else
-            {
-                expectdRequestContent = $"country=GB&msisdn=447700900000&api_key={ApiKey}&api_secret={ApiSecret}&";
-                request = new NumberTransactionRequest { Country = "GB", Msisdn = "447700900000" };
-            }
-
-            Setup(expectedUri, expectedResponse, expectdRequestContent);
-
-            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
-            var client = new VonageClient(creds);
-            NumberTransactionResponse response;
-            if (passCreds)
-            {
-                response = await client.NumbersClient.BuyANumberAsync(request, creds);
-            }
-            else
-            {
-                response = await client.NumbersClient.BuyANumberAsync(request);
-            }
-
-            Assert.Equal("200", response.ErrorCode);
-            Assert.Equal("success", response.ErrorCodeLabel);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public void TestCancelNumber(bool passCreds, bool kitchenSink)
-        {
-            var expectedResponse = @"{
-              ""error-code"": ""200"",
-              ""error-code-label"": ""success""
-            }";
-            var expectedUri = $"{RestUrl}/number/cancel";
-            string expectdRequestContent = $"country=GB&msisdn=447700900000&api_key={ApiKey}&api_secret={ApiSecret}&";
-            NumberTransactionRequest request;
-
-            if (kitchenSink)
-            {
-                expectdRequestContent = $"country=GB&msisdn=447700900000&target_api_key=12345&api_key={ApiKey}&api_secret={ApiSecret}&";
-                request = new NumberTransactionRequest { Country = "GB", Msisdn = "447700900000", TargetApiKey = "12345" };
-            }
-            else
-            {
-                expectdRequestContent = $"country=GB&msisdn=447700900000&api_key={ApiKey}&api_secret={ApiSecret}&";
-                request = new NumberTransactionRequest { Country = "GB", Msisdn = "447700900000" };
-            }
-
-            Setup(expectedUri, expectedResponse, expectdRequestContent);
-
-            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
-            var client = new VonageClient(creds);
-            NumberTransactionResponse response;
-            if (passCreds)
-            {
-                response = client.NumbersClient.CancelANumber(request, creds);
-            }
-            else
-            {
-                response = client.NumbersClient.CancelANumber(request);
-            }
-
-            Assert.Equal("200", response.ErrorCode);
-            Assert.Equal("success", response.ErrorCodeLabel);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public async void TestCancelNumberAsync(bool passCreds, bool kitchenSink)
-        {
-            var expectedResponse = @"{
-              ""error-code"": ""200"",
-              ""error-code-label"": ""success""
-            }";
-            var expectedUri = $"{RestUrl}/number/cancel";
-            string expectdRequestContent = $"country=GB&msisdn=447700900000&api_key={ApiKey}&api_secret={ApiSecret}&";
-            NumberTransactionRequest request;
-
-            if (kitchenSink)
-            {
-                expectdRequestContent = $"country=GB&msisdn=447700900000&target_api_key=12345&api_key={ApiKey}&api_secret={ApiSecret}&";
-                request = new NumberTransactionRequest { Country = "GB", Msisdn = "447700900000", TargetApiKey = "12345" };
-            }
-            else
-            {
-                expectdRequestContent = $"country=GB&msisdn=447700900000&api_key={ApiKey}&api_secret={ApiSecret}&";
-                request = new NumberTransactionRequest { Country = "GB", Msisdn = "447700900000" };
-            }
-
-            Setup(expectedUri, expectedResponse, expectdRequestContent);
-
-            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
-            var client = new VonageClient(creds);
-            NumberTransactionResponse response;
-            if (passCreds)
-            {
-                response = await client.NumbersClient.CancelANumberAsync(request, creds);
-            }
-            else
-            {
-                response = await client.NumbersClient.CancelANumberAsync(request);
-            }
-
-            Assert.Equal("200", response.ErrorCode);
-            Assert.Equal("success", response.ErrorCodeLabel);
-        }
-
-        [Theory]
-        [InlineData(true,true)]
-        [InlineData(false,false)]
-        public void TestUpdateNumber(bool passCreds, bool kitchenSink)
-        {
-            var expectedResponse = @"{
-              ""error-code"": ""200"",
-              ""error-code-label"": ""success""
-            }";
-            var expectedUri = $"{RestUrl}/number/update";
-            string expectdRequestContent;
             UpdateNumberRequest request;
-
             if (kitchenSink)
-            {                
-                expectdRequestContent = $"country=GB&msisdn=447700900000&app_id=aaaaaaaa-bbbb-cccc-dddd-0123456789abc&moHttpUrl={HttpUtility.UrlEncode("https://example.com/webhooks/inbound-sms")}&" +
-                    $"moSmppSysType=inbound&voiceCallbackType=tel&voiceCallbackValue=447700900000&voiceStatusCallback={HttpUtility.UrlEncode("https://example.com/webhooks/status")}&" +
-                    $"api_key={ApiKey}&api_secret={ApiSecret}&";
-                request = new UpdateNumberRequest 
-                { 
-                    Country = "GB", 
-                    Msisdn = "447700900000", 
-                    AppId= "aaaaaaaa-bbbb-cccc-dddd-0123456789abc", 
-                    MoHttpUrl= "https://example.com/webhooks/inbound-sms",
-                    MoSmppSysType="inbound",
-                    VoiceCallbackType="tel",
-                    VoiceCallbackValue= "447700900000",
-                    VoiceStatusCallback= "https://example.com/webhooks/status"
+            {
+                expectedRequestContent =
+                    $"country=GB&msisdn=447700900000&app_id=aaaaaaaa-bbbb-cccc-dddd-0123456789abc&moHttpUrl={HttpUtility.UrlEncode("https://example.com/webhooks/inbound-sms")}&" +
+                    $"moSmppSysType=inbound&voiceCallbackType=tel&voiceCallbackValue=447700900000&voiceStatusCallback={HttpUtility.UrlEncode("https://example.com/webhooks/status")}&";
+                request = new UpdateNumberRequest
+                {
+                    Country = "GB",
+                    Msisdn = "447700900000",
+                    AppId = "aaaaaaaa-bbbb-cccc-dddd-0123456789abc",
+                    MoHttpUrl = "https://example.com/webhooks/inbound-sms",
+                    MoSmppSysType = "inbound",
+                    VoiceCallbackType = "tel",
+                    VoiceCallbackValue = "447700900000",
+                    VoiceStatusCallback = "https://example.com/webhooks/status",
                 };
             }
             else
             {
-                expectdRequestContent = $"country=GB&msisdn=447700900000&api_key={ApiKey}&api_secret={ApiSecret}&";
-                request = new UpdateNumberRequest { Country = "GB", Msisdn = "447700900000" };
+                expectedRequestContent = "country=GB&msisdn=447700900000&";
+                request = new UpdateNumberRequest {Country = "GB", Msisdn = "447700900000"};
             }
 
-            Setup(expectedUri, expectedResponse, expectdRequestContent);
-
-            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
-            var client = new VonageClient(creds);
+            this.Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var credentials = Credentials.FromApiKeyAndSecret(this.ApiKey, this.ApiSecret);
+            var client = new VonageClient(credentials);
             NumberTransactionResponse response;
-            if (passCreds)
+            if (passCredentials)
             {
-                response = client.NumbersClient.UpdateANumber(request, creds);
+                response = client.NumbersClient.UpdateANumber(request, credentials);
             }
             else
             {
@@ -347,21 +373,20 @@ namespace Vonage.Test.Unit
         [Theory]
         [InlineData(true, true)]
         [InlineData(false, false)]
-        public async void TestUpdateNumberAsync(bool passCreds, bool kitchenSink)
+        public async void TestUpdateNumberAsync(bool passCredentials, bool kitchenSink)
         {
-            var expectedResponse = @"{
+            const string expectedResponse = @"{
               ""error-code"": ""200"",
               ""error-code-label"": ""success""
             }";
-            var expectedUri = $"{RestUrl}/number/update";
-            string expectdRequestContent;
+            var expectedUri = $"{this.RestUrl}/number/update?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
+            string expectedRequestContent;
             UpdateNumberRequest request;
-
             if (kitchenSink)
             {
-                expectdRequestContent = $"country=GB&msisdn=447700900000&app_id=aaaaaaaa-bbbb-cccc-dddd-0123456789abc&moHttpUrl={HttpUtility.UrlEncode("https://example.com/webhooks/inbound-sms")}&" +
-                    $"moSmppSysType=inbound&voiceCallbackType=tel&voiceCallbackValue=447700900000&voiceStatusCallback={HttpUtility.UrlEncode("https://example.com/webhooks/status")}&" +
-                    $"api_key={ApiKey}&api_secret={ApiSecret}&";
+                expectedRequestContent =
+                    $"country=GB&msisdn=447700900000&app_id=aaaaaaaa-bbbb-cccc-dddd-0123456789abc&moHttpUrl={HttpUtility.UrlEncode("https://example.com/webhooks/inbound-sms")}&" +
+                    $"moSmppSysType=inbound&voiceCallbackType=tel&voiceCallbackValue=447700900000&voiceStatusCallback={HttpUtility.UrlEncode("https://example.com/webhooks/status")}&";
                 request = new UpdateNumberRequest
                 {
                     Country = "GB",
@@ -371,23 +396,22 @@ namespace Vonage.Test.Unit
                     MoSmppSysType = "inbound",
                     VoiceCallbackType = "tel",
                     VoiceCallbackValue = "447700900000",
-                    VoiceStatusCallback = "https://example.com/webhooks/status"
+                    VoiceStatusCallback = "https://example.com/webhooks/status",
                 };
             }
             else
             {
-                expectdRequestContent = $"country=GB&msisdn=447700900000&api_key={ApiKey}&api_secret={ApiSecret}&";
-                request = new UpdateNumberRequest { Country = "GB", Msisdn = "447700900000" };
+                expectedRequestContent = "country=GB&msisdn=447700900000&";
+                request = new UpdateNumberRequest {Country = "GB", Msisdn = "447700900000"};
             }
 
-            Setup(expectedUri, expectedResponse, expectdRequestContent);
-
-            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
-            var client = new VonageClient(creds);
+            this.Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var credentials = Credentials.FromApiKeyAndSecret(this.ApiKey, this.ApiSecret);
+            var client = new VonageClient(credentials);
             NumberTransactionResponse response;
-            if (passCreds)
+            if (passCredentials)
             {
-                response = await client.NumbersClient.UpdateANumberAsync(request, creds);
+                response = await client.NumbersClient.UpdateANumberAsync(request, credentials);
             }
             else
             {
@@ -397,31 +421,5 @@ namespace Vonage.Test.Unit
             Assert.Equal("200", response.ErrorCode);
             Assert.Equal("success", response.ErrorCodeLabel);
         }
-
-        [Fact]
-        public void TestFailedPurchase()
-        {
-            var expectedResponse = @"{
-              ""error-code"": ""401"",
-              ""error-code-label"": ""authentifcation failed""
-            }";
-            var expectedUri = $"{RestUrl}/number/buy";
-            string expectdRequestContent = $"country=GB&msisdn=447700900000&api_key={ApiKey}&api_secret={ApiSecret}&";
-            Setup(expectedUri, expectedResponse, expectdRequestContent);
-            var request = new NumberTransactionRequest { Country = "GB", Msisdn = "447700900000" };
-            var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
-            var client = new VonageClient(creds);
-            try
-            {
-                client.NumbersClient.BuyANumber(request);
-                Assert.True(false, "Failin because exception was not thrown");
-            }
-            catch (VonageNumberResponseException ex)
-            {
-                Assert.Equal("401", ex.Response.ErrorCode);
-                Assert.Equal("authentifcation failed", ex.Response.ErrorCodeLabel);
-            }
-        }
-        
     }
 }

--- a/Vonage.Test.Unit/NumbersTests.cs
+++ b/Vonage.Test.Unit/NumbersTests.cs
@@ -1,4 +1,7 @@
-﻿using System.Web;
+﻿using System;
+using System.Threading.Tasks;
+using System.Web;
+using FluentAssertions;
 using Vonage.Numbers;
 using Vonage.Request;
 using Xunit;
@@ -7,246 +10,148 @@ namespace Vonage.Test.Unit
 {
     public class NumbersTests : TestBase
     {
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public void TestBuyNumber(bool passCredentials, bool kitchenSink)
+        private readonly Credentials credentials;
+        private readonly VonageClient client;
+
+        public NumbersTests()
         {
-            var expectedResponse = @"{
-              ""error-code"": ""200"",
-              ""error-code-label"": ""success""
-            }";
+            this.credentials = this.BuildCredentials();
+            this.client = new VonageClient(this.credentials);
+        }
+
+        [Fact]
+        public void TestBuyNumber()
+        {
+            const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
+            const string expectedRequestContent = "country=GB&msisdn=447700900000&";
             var expectedUri = $"{this.RestUrl}/number/buy?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
-            string expectedRequestContent;
-            NumberTransactionRequest request;
-            if (kitchenSink)
-            {
-                expectedRequestContent = "country=GB&msisdn=447700900000&target_api_key=12345&";
-                request = new NumberTransactionRequest
-                    {Country = "GB", Msisdn = "447700900000", TargetApiKey = "12345"};
-            }
-            else
-            {
-                expectedRequestContent = "country=GB&msisdn=447700900000&";
-                request = new NumberTransactionRequest {Country = "GB", Msisdn = "447700900000"};
-            }
-
+            var request = new NumberTransactionRequest {Country = "GB", Msisdn = "447700900000"};
             this.Setup(expectedUri, expectedResponse, expectedRequestContent);
-            var credentials = Credentials.FromApiKeyAndSecret(this.ApiKey, this.ApiSecret);
-            var client = new VonageClient(credentials);
-            NumberTransactionResponse response;
-            if (passCredentials)
-            {
-                response = client.NumbersClient.BuyANumber(request, credentials);
-            }
-            else
-            {
-                response = client.NumbersClient.BuyANumber(request);
-            }
-
-            Assert.Equal("200", response.ErrorCode);
-            Assert.Equal("success", response.ErrorCodeLabel);
+            var response = this.client.NumbersClient.BuyANumber(request);
+            response.ErrorCode.Should().Be("200");
+            response.ErrorCodeLabel.Should().Be("success");
         }
 
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public async void TestBuyNumberAsync(bool passCredentials, bool kitchenSink)
+        [Fact]
+        public async Task TestBuyNumberAsync()
         {
-            var expectedResponse = @"{
-              ""error-code"": ""200"",
-              ""error-code-label"": ""success""
-            }";
+            const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
+            const string expectedRequestContent = "country=GB&msisdn=447700900000&";
             var expectedUri = $"{this.RestUrl}/number/buy?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
-            string expectedRequestContent;
-            NumberTransactionRequest request;
-            if (kitchenSink)
-            {
-                expectedRequestContent = "country=GB&msisdn=447700900000&target_api_key=12345&";
-                request = new NumberTransactionRequest
-                    {Country = "GB", Msisdn = "447700900000", TargetApiKey = "12345"};
-            }
-            else
-            {
-                expectedRequestContent = "country=GB&msisdn=447700900000&";
-                request = new NumberTransactionRequest {Country = "GB", Msisdn = "447700900000"};
-            }
-
+            var request = new NumberTransactionRequest {Country = "GB", Msisdn = "447700900000"};
             this.Setup(expectedUri, expectedResponse, expectedRequestContent);
-            var credentials = Credentials.FromApiKeyAndSecret(this.ApiKey, this.ApiSecret);
-            var client = new VonageClient(credentials);
-            NumberTransactionResponse response;
-            if (passCredentials)
-            {
-                response = await client.NumbersClient.BuyANumberAsync(request, credentials);
-            }
-            else
-            {
-                response = await client.NumbersClient.BuyANumberAsync(request);
-            }
-
-            Assert.Equal("200", response.ErrorCode);
-            Assert.Equal("success", response.ErrorCodeLabel);
+            var response = await this.client.NumbersClient.BuyANumberAsync(request);
+            response.ErrorCode.Should().Be("200");
+            response.ErrorCodeLabel.Should().Be("success");
         }
 
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public void TestCancelNumber(bool passCredentials, bool kitchenSink)
+        [Fact]
+        public async Task TestBuyNumberAsyncWithCredentials()
         {
-            var expectedResponse = @"{
-              ""error-code"": ""200"",
-              ""error-code-label"": ""success""
-            }";
-            var expectedUri = $"{this.RestUrl}/number/cancel?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
-            string expectedRequestContent;
-            NumberTransactionRequest request;
-            if (kitchenSink)
-            {
-                expectedRequestContent = "country=GB&msisdn=447700900000&target_api_key=12345&";
-                request = new NumberTransactionRequest
-                    {Country = "GB", Msisdn = "447700900000", TargetApiKey = "12345"};
-            }
-            else
-            {
-                expectedRequestContent = "country=GB&msisdn=447700900000&";
-                request = new NumberTransactionRequest {Country = "GB", Msisdn = "447700900000"};
-            }
-
+            const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
+            const string expectedRequestContent = "country=GB&msisdn=447700900000&target_api_key=12345&";
+            var expectedUri = $"{this.RestUrl}/number/buy?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
             this.Setup(expectedUri, expectedResponse, expectedRequestContent);
-            var credentials = Credentials.FromApiKeyAndSecret(this.ApiKey, this.ApiSecret);
-            var client = new VonageClient(credentials);
-            NumberTransactionResponse response;
-            if (passCredentials)
-            {
-                response = client.NumbersClient.CancelANumber(request, credentials);
-            }
-            else
-            {
-                response = client.NumbersClient.CancelANumber(request);
-            }
-
-            Assert.Equal("200", response.ErrorCode);
-            Assert.Equal("success", response.ErrorCodeLabel);
+            var request = new NumberTransactionRequest
+                {Country = "GB", Msisdn = "447700900000", TargetApiKey = "12345"};
+            var response = await this.client.NumbersClient.BuyANumberAsync(request, this.credentials);
+            response.ErrorCode.Should().Be("200");
+            response.ErrorCodeLabel.Should().Be("success");
         }
 
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public async void TestCancelNumberAsync(bool passCredentials, bool kitchenSink)
+        [Fact]
+        public void TestBuyNumberWithCredentials()
         {
-            const string expectedResponse = @"{
-              ""error-code"": ""200"",
-              ""error-code-label"": ""success""
-            }";
-            var expectedUri = $"{this.RestUrl}/number/cancel?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
-            string expectedRequestContent;
-            NumberTransactionRequest request;
-            if (kitchenSink)
-            {
-                expectedRequestContent = "country=GB&msisdn=447700900000&target_api_key=12345&";
-                request = new NumberTransactionRequest
-                    {Country = "GB", Msisdn = "447700900000", TargetApiKey = "12345"};
-            }
-            else
-            {
-                expectedRequestContent = "country=GB&msisdn=447700900000&";
-                request = new NumberTransactionRequest {Country = "GB", Msisdn = "447700900000"};
-            }
-
+            const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
+            const string expectedRequestContent = "country=GB&msisdn=447700900000&target_api_key=12345&";
+            var expectedUri = $"{this.RestUrl}/number/buy?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
             this.Setup(expectedUri, expectedResponse, expectedRequestContent);
-            var credentials = Credentials.FromApiKeyAndSecret(this.ApiKey, this.ApiSecret);
-            var client = new VonageClient(credentials);
-            NumberTransactionResponse response;
-            if (passCredentials)
-            {
-                response = await client.NumbersClient.CancelANumberAsync(request, credentials);
-            }
-            else
-            {
-                response = await client.NumbersClient.CancelANumberAsync(request);
-            }
+            var request = new NumberTransactionRequest
+                {Country = "GB", Msisdn = "447700900000", TargetApiKey = "12345"};
+            var response = this.client.NumbersClient.BuyANumber(request, this.credentials);
+            response.ErrorCode.Should().Be("200");
+            response.ErrorCodeLabel.Should().Be("success");
+        }
 
-            Assert.Equal("200", response.ErrorCode);
-            Assert.Equal("success", response.ErrorCodeLabel);
+        [Fact]
+        public void TestCancelNumber()
+        {
+            const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
+            const string expectedRequestContent = "country=GB&msisdn=447700900000&";
+            var expectedUri = $"{this.RestUrl}/number/cancel?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
+            var request = new NumberTransactionRequest {Country = "GB", Msisdn = "447700900000"};
+            this.Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var response = this.client.NumbersClient.CancelANumber(request);
+            response.ErrorCode.Should().Be("200");
+            response.ErrorCodeLabel.Should().Be("success");
+        }
+
+        [Fact]
+        public async Task TestCancelNumberAsync()
+        {
+            const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
+            const string expectedRequestContent = "country=GB&msisdn=447700900000&";
+            var expectedUri = $"{this.RestUrl}/number/cancel?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
+            var request = new NumberTransactionRequest {Country = "GB", Msisdn = "447700900000"};
+            this.Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var response = await this.client.NumbersClient.CancelANumberAsync(request);
+            response.ErrorCode.Should().Be("200");
+            response.ErrorCodeLabel.Should().Be("success");
+        }
+
+        [Fact]
+        public async Task TestCancelNumberAsyncWithCredentials()
+        {
+            const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
+            const string expectedRequestContent = "country=GB&msisdn=447700900000&target_api_key=12345&";
+            var expectedUri = $"{this.RestUrl}/number/cancel?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
+            var request = new NumberTransactionRequest
+                {Country = "GB", Msisdn = "447700900000", TargetApiKey = "12345"};
+            this.Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var response = await this.client.NumbersClient.CancelANumberAsync(request, this.credentials);
+            response.ErrorCode.Should().Be("200");
+            response.ErrorCodeLabel.Should().Be("success");
+        }
+
+        [Fact]
+        public void TestCancelNumberWithCredentials()
+        {
+            const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
+            const string expectedRequestContent = "country=GB&msisdn=447700900000&target_api_key=12345&";
+            var expectedUri = $"{this.RestUrl}/number/cancel?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
+            var request = new NumberTransactionRequest
+                {Country = "GB", Msisdn = "447700900000", TargetApiKey = "12345"};
+            this.Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var response = this.client.NumbersClient.CancelANumber(request, this.credentials);
+            response.ErrorCode.Should().Be("200");
+            response.ErrorCodeLabel.Should().Be("success");
         }
 
         [Fact]
         public void TestFailedPurchase()
         {
-            const string expectedResponse = @"{
-              ""error-code"": ""401"",
-              ""error-code-label"": ""authentifcation failed""
-            }";
+            const string expectedResponse =
+                @"{""error-code"": ""401"",""error-code-label"": ""authentication failed""}";
+            const string expectedRequestContent = "country=GB&msisdn=447700900000&";
             var expectedUri = $"{this.RestUrl}/number/buy?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
-            var expectedRequestContent = "country=GB&msisdn=447700900000&";
             this.Setup(expectedUri, expectedResponse, expectedRequestContent);
             var request = new NumberTransactionRequest {Country = "GB", Msisdn = "447700900000"};
-            var credentials = Credentials.FromApiKeyAndSecret(this.ApiKey, this.ApiSecret);
-            var client = new VonageClient(credentials);
-            try
-            {
-                client.NumbersClient.BuyANumber(request);
-                Assert.True(false, "Failin because exception was not thrown");
-            }
-            catch (VonageNumberResponseException ex)
-            {
-                Assert.Equal("401", ex.Response.ErrorCode);
-                Assert.Equal("authentifcation failed", ex.Response.ErrorCodeLabel);
-            }
+            Action act = () => this.client.NumbersClient.BuyANumber(request);
+            act.Should().ThrowExactly<VonageNumberResponseException>()
+                .Which.Response.Should().BeEquivalentTo(new NumberTransactionResponse
+                    {ErrorCode = "401", ErrorCodeLabel = "authentication failed"});
         }
 
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public void TestSearchNumbers(bool passCredentials, bool kitchenSink)
+        [Fact]
+        public void TestSearchNumbers()
         {
-            const string expectedResponse = @"{
-              ""count"": 1234,
-              ""numbers"": [
-                {
-                  ""country"": ""GB"",
-                  ""msisdn"": ""447700900000"",
-                  ""type"": ""mobile-lvn"",
-                  ""cost"": ""1.25"",
-                  ""features"": [
-                    ""VOICE"",
-                    ""SMS""
-                  ]
-                }
-              ]
-            }";
-            var expectedUri = $"{this.RestUrl}/number/search";
-            NumberSearchRequest request;
-            if (kitchenSink)
-            {
-                expectedUri +=
-                    $"?country=GB&type=mobile-lvn&pattern=12345&search_pattern=1&features=SMS&size=10&index=1&api_key={this.ApiKey}&api_secret={this.ApiSecret}&";
-                request = new NumberSearchRequest
-                {
-                    Country = "GB", Type = "mobile-lvn", Pattern = "12345", SearchPattern = SearchPattern.Contains,
-                    Features = "SMS", Size = 10, Index = 1,
-                };
-            }
-            else
-            {
-                expectedUri += $"?country=GB&api_key={this.ApiKey}&api_secret={this.ApiSecret}&";
-                request = new NumberSearchRequest {Country = "GB"};
-            }
-
+            const string expectedResponse =
+                @"{""count"": 1234,""numbers"": [{""country"": ""GB"",""msisdn"": ""447700900000"",""type"": ""mobile-lvn"",""cost"": ""1.25"",""features"": [""VOICE"",""SMS""]}]}";
+            var expectedUri =
+                $"{this.RestUrl}/number/search?country=GB&api_key={this.ApiKey}&api_secret={this.ApiSecret}&";
+            var request = new NumberSearchRequest {Country = "GB"};
             this.Setup(expectedUri, expectedResponse);
-            var credentials = Credentials.FromApiKeyAndSecret(this.ApiKey, this.ApiSecret);
-            var client = new VonageClient(credentials);
-            NumbersSearchResponse response;
-            if (passCredentials)
-            {
-                response = client.NumbersClient.GetAvailableNumbers(request, credentials);
-            }
-            else
-            {
-                response = client.NumbersClient.GetAvailableNumbers(request);
-            }
-
+            var response = this.client.NumbersClient.GetAvailableNumbers(request);
             var number = response.Numbers[0];
             Assert.Equal(1234, response.Count);
             Assert.Equal("GB", number.Country);
@@ -257,57 +162,16 @@ namespace Vonage.Test.Unit
             Assert.Equal("SMS", number.Features[1]);
         }
 
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public async void TestSearchNumbersAsync(bool passCredentials, bool kitchenSink)
+        [Fact]
+        public async Task TestSearchNumbersAsync()
         {
-            const string expectedResponse = @"{
-              ""count"": 1234,
-              ""numbers"": [
-                {
-                  ""country"": ""GB"",
-                  ""msisdn"": ""447700900000"",
-                  ""type"": ""mobile-lvn"",
-                  ""cost"": ""1.25"",
-                  ""features"": [
-                    ""VOICE"",
-                    ""SMS""
-                  ]
-                }
-              ]
-            }";
-            var expectedUri = $"{this.RestUrl}/number/search";
-            NumberSearchRequest request;
-            if (kitchenSink)
-            {
-                expectedUri +=
-                    $"?country=GB&type=mobile-lvn&pattern=12345&search_pattern=1&features=SMS&size=10&index=1&api_key={this.ApiKey}&api_secret={this.ApiSecret}&";
-                request = new NumberSearchRequest
-                {
-                    Country = "GB", Type = "mobile-lvn", Pattern = "12345", SearchPattern = SearchPattern.Contains,
-                    Features = "SMS", Size = 10, Index = 1,
-                };
-            }
-            else
-            {
-                expectedUri += $"?country=GB&api_key={this.ApiKey}&api_secret={this.ApiSecret}&";
-                request = new NumberSearchRequest {Country = "GB"};
-            }
-
+            const string expectedResponse =
+                @"{""count"": 1234,""numbers"": [{""country"": ""GB"",""msisdn"": ""447700900000"",""type"": ""mobile-lvn"",""cost"": ""1.25"",""features"": [""VOICE"",""SMS""]}]}";
+            var expectedUri =
+                $"{this.RestUrl}/number/search?country=GB&api_key={this.ApiKey}&api_secret={this.ApiSecret}&";
+            var request = new NumberSearchRequest {Country = "GB"};
             this.Setup(expectedUri, expectedResponse);
-            var credentials = Credentials.FromApiKeyAndSecret(this.ApiKey, this.ApiSecret);
-            var client = new VonageClient(credentials);
-            NumbersSearchResponse response;
-            if (passCredentials)
-            {
-                response = await client.NumbersClient.GetAvailableNumbersAsync(request, credentials);
-            }
-            else
-            {
-                response = await client.NumbersClient.GetAvailableNumbersAsync(request);
-            }
-
+            var response = await this.client.NumbersClient.GetAvailableNumbersAsync(request);
             var number = response.Numbers[0];
             Assert.Equal(1234, response.Count);
             Assert.Equal("GB", number.Country);
@@ -318,108 +182,130 @@ namespace Vonage.Test.Unit
             Assert.Equal("SMS", number.Features[1]);
         }
 
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public void TestUpdateNumber(bool passCredentials, bool kitchenSink)
+        [Fact]
+        public async Task TestSearchNumbersAsyncWithCredentials()
         {
-            const string expectedResponse = @"{
-              ""error-code"": ""200"",
-              ""error-code-label"": ""success""
-            }";
-            var expectedUri = $"{this.RestUrl}/number/update?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
-            string expectedRequestContent;
-            UpdateNumberRequest request;
-            if (kitchenSink)
+            const string expectedResponse =
+                @"{""count"": 1234,""numbers"": [{""country"": ""GB"",""msisdn"": ""447700900000"",""type"": ""mobile-lvn"",""cost"": ""1.25"",""features"": [""VOICE"",""SMS""]}]}";
+            var expectedUri =
+                $"{this.RestUrl}/number/search?country=GB&type=mobile-lvn&pattern=12345&search_pattern=1&features=SMS&size=10&index=1&api_key={this.ApiKey}&api_secret={this.ApiSecret}&";
+            var request = new NumberSearchRequest
             {
-                expectedRequestContent =
-                    $"country=GB&msisdn=447700900000&app_id=aaaaaaaa-bbbb-cccc-dddd-0123456789abc&moHttpUrl={HttpUtility.UrlEncode("https://example.com/webhooks/inbound-sms")}&" +
-                    $"moSmppSysType=inbound&voiceCallbackType=tel&voiceCallbackValue=447700900000&voiceStatusCallback={HttpUtility.UrlEncode("https://example.com/webhooks/status")}&";
-                request = new UpdateNumberRequest
-                {
-                    Country = "GB",
-                    Msisdn = "447700900000",
-                    AppId = "aaaaaaaa-bbbb-cccc-dddd-0123456789abc",
-                    MoHttpUrl = "https://example.com/webhooks/inbound-sms",
-                    MoSmppSysType = "inbound",
-                    VoiceCallbackType = "tel",
-                    VoiceCallbackValue = "447700900000",
-                    VoiceStatusCallback = "https://example.com/webhooks/status",
-                };
-            }
-            else
-            {
-                expectedRequestContent = "country=GB&msisdn=447700900000&";
-                request = new UpdateNumberRequest {Country = "GB", Msisdn = "447700900000"};
-            }
-
-            this.Setup(expectedUri, expectedResponse, expectedRequestContent);
-            var credentials = Credentials.FromApiKeyAndSecret(this.ApiKey, this.ApiSecret);
-            var client = new VonageClient(credentials);
-            NumberTransactionResponse response;
-            if (passCredentials)
-            {
-                response = client.NumbersClient.UpdateANumber(request, credentials);
-            }
-            else
-            {
-                response = client.NumbersClient.UpdateANumber(request);
-            }
-
-            Assert.Equal("200", response.ErrorCode);
-            Assert.Equal("success", response.ErrorCodeLabel);
+                Country = "GB", Type = "mobile-lvn", Pattern = "12345", SearchPattern = SearchPattern.Contains,
+                Features = "SMS", Size = 10, Index = 1,
+            };
+            this.Setup(expectedUri, expectedResponse);
+            var response = await this.client.NumbersClient.GetAvailableNumbersAsync(request, this.credentials);
+            var number = response.Numbers[0];
+            Assert.Equal(1234, response.Count);
+            Assert.Equal("GB", number.Country);
+            Assert.Equal("447700900000", number.Msisdn);
+            Assert.Equal("mobile-lvn", number.Type);
+            Assert.Equal("1.25", number.Cost);
+            Assert.Equal("VOICE", number.Features[0]);
+            Assert.Equal("SMS", number.Features[1]);
         }
 
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(false, false)]
-        public async void TestUpdateNumberAsync(bool passCredentials, bool kitchenSink)
+        [Fact]
+        public void TestSearchNumbersWithCredentials()
         {
-            const string expectedResponse = @"{
-              ""error-code"": ""200"",
-              ""error-code-label"": ""success""
-            }";
-            var expectedUri = $"{this.RestUrl}/number/update?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
-            string expectedRequestContent;
-            UpdateNumberRequest request;
-            if (kitchenSink)
+            const string expectedResponse =
+                @"{""count"": 1234,""numbers"": [{""country"": ""GB"",""msisdn"": ""447700900000"",""type"": ""mobile-lvn"",""cost"": ""1.25"",""features"": [""VOICE"",""SMS""]}]}";
+            var expectedUri =
+                $"{this.RestUrl}/number/search?country=GB&type=mobile-lvn&pattern=12345&search_pattern=1&features=SMS&size=10&index=1&api_key={this.ApiKey}&api_secret={this.ApiSecret}&";
+            var request = new NumberSearchRequest
             {
-                expectedRequestContent =
-                    $"country=GB&msisdn=447700900000&app_id=aaaaaaaa-bbbb-cccc-dddd-0123456789abc&moHttpUrl={HttpUtility.UrlEncode("https://example.com/webhooks/inbound-sms")}&" +
-                    $"moSmppSysType=inbound&voiceCallbackType=tel&voiceCallbackValue=447700900000&voiceStatusCallback={HttpUtility.UrlEncode("https://example.com/webhooks/status")}&";
-                request = new UpdateNumberRequest
-                {
-                    Country = "GB",
-                    Msisdn = "447700900000",
-                    AppId = "aaaaaaaa-bbbb-cccc-dddd-0123456789abc",
-                    MoHttpUrl = "https://example.com/webhooks/inbound-sms",
-                    MoSmppSysType = "inbound",
-                    VoiceCallbackType = "tel",
-                    VoiceCallbackValue = "447700900000",
-                    VoiceStatusCallback = "https://example.com/webhooks/status",
-                };
-            }
-            else
-            {
-                expectedRequestContent = "country=GB&msisdn=447700900000&";
-                request = new UpdateNumberRequest {Country = "GB", Msisdn = "447700900000"};
-            }
-
-            this.Setup(expectedUri, expectedResponse, expectedRequestContent);
-            var credentials = Credentials.FromApiKeyAndSecret(this.ApiKey, this.ApiSecret);
-            var client = new VonageClient(credentials);
-            NumberTransactionResponse response;
-            if (passCredentials)
-            {
-                response = await client.NumbersClient.UpdateANumberAsync(request, credentials);
-            }
-            else
-            {
-                response = await client.NumbersClient.UpdateANumberAsync(request);
-            }
-
-            Assert.Equal("200", response.ErrorCode);
-            Assert.Equal("success", response.ErrorCodeLabel);
+                Country = "GB", Type = "mobile-lvn", Pattern = "12345", SearchPattern = SearchPattern.Contains,
+                Features = "SMS", Size = 10, Index = 1,
+            };
+            this.Setup(expectedUri, expectedResponse);
+            var response = this.client.NumbersClient.GetAvailableNumbers(request, this.credentials);
+            var number = response.Numbers[0];
+            Assert.Equal(1234, response.Count);
+            Assert.Equal("GB", number.Country);
+            Assert.Equal("447700900000", number.Msisdn);
+            Assert.Equal("mobile-lvn", number.Type);
+            Assert.Equal("1.25", number.Cost);
+            Assert.Equal("VOICE", number.Features[0]);
+            Assert.Equal("SMS", number.Features[1]);
         }
+
+        [Fact]
+        public void TestUpdateNumber()
+        {
+            const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
+            const string expectedRequestContent = "country=GB&msisdn=447700900000&";
+            var expectedUri = $"{this.RestUrl}/number/update?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
+            var request = new UpdateNumberRequest {Country = "GB", Msisdn = "447700900000"};
+            this.Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var response = this.client.NumbersClient.UpdateANumber(request);
+            response.ErrorCode.Should().Be("200");
+            response.ErrorCodeLabel.Should().Be("success");
+        }
+
+        [Fact]
+        public async Task TestUpdateNumberAsync()
+        {
+            const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
+            const string expectedRequestContent = "country=GB&msisdn=447700900000&";
+            var expectedUri = $"{this.RestUrl}/number/update?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
+            var request = new UpdateNumberRequest {Country = "GB", Msisdn = "447700900000"};
+            this.Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var response = await this.client.NumbersClient.UpdateANumberAsync(request);
+            response.ErrorCode.Should().Be("200");
+            response.ErrorCodeLabel.Should().Be("success");
+        }
+
+        [Fact]
+        public async Task TestUpdateNumberAsyncWithCredentials()
+        {
+            const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
+            var expectedUri = $"{this.RestUrl}/number/update?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
+            var expectedRequestContent =
+                $"country=GB&msisdn=447700900000&app_id=aaaaaaaa-bbbb-cccc-dddd-0123456789abc&moHttpUrl={HttpUtility.UrlEncode("https://example.com/webhooks/inbound-sms")}&" +
+                $"moSmppSysType=inbound&voiceCallbackType=tel&voiceCallbackValue=447700900000&voiceStatusCallback={HttpUtility.UrlEncode("https://example.com/webhooks/status")}&";
+            var request = new UpdateNumberRequest
+            {
+                Country = "GB",
+                Msisdn = "447700900000",
+                AppId = "aaaaaaaa-bbbb-cccc-dddd-0123456789abc",
+                MoHttpUrl = "https://example.com/webhooks/inbound-sms",
+                MoSmppSysType = "inbound",
+                VoiceCallbackType = "tel",
+                VoiceCallbackValue = "447700900000",
+                VoiceStatusCallback = "https://example.com/webhooks/status",
+            };
+            this.Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var response = await this.client.NumbersClient.UpdateANumberAsync(request, this.credentials);
+            response.ErrorCode.Should().Be("200");
+            response.ErrorCodeLabel.Should().Be("success");
+        }
+
+        [Fact]
+        public void TestUpdateNumberWithCredentials()
+        {
+            const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
+            var expectedUri = $"{this.RestUrl}/number/update?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
+            var expectedRequestContent =
+                $"country=GB&msisdn=447700900000&app_id=aaaaaaaa-bbbb-cccc-dddd-0123456789abc&moHttpUrl={HttpUtility.UrlEncode("https://example.com/webhooks/inbound-sms")}&" +
+                $"moSmppSysType=inbound&voiceCallbackType=tel&voiceCallbackValue=447700900000&voiceStatusCallback={HttpUtility.UrlEncode("https://example.com/webhooks/status")}&";
+            var request = new UpdateNumberRequest
+            {
+                Country = "GB",
+                Msisdn = "447700900000",
+                AppId = "aaaaaaaa-bbbb-cccc-dddd-0123456789abc",
+                MoHttpUrl = "https://example.com/webhooks/inbound-sms",
+                MoSmppSysType = "inbound",
+                VoiceCallbackType = "tel",
+                VoiceCallbackValue = "447700900000",
+                VoiceStatusCallback = "https://example.com/webhooks/status",
+            };
+            this.Setup(expectedUri, expectedResponse, expectedRequestContent);
+            var response = this.client.NumbersClient.UpdateANumber(request, this.credentials);
+            response.ErrorCode.Should().Be("200");
+            response.ErrorCodeLabel.Should().Be("success");
+        }
+
+        private Credentials BuildCredentials() => Credentials.FromApiKeyAndSecret(this.ApiKey, this.ApiSecret);
     }
 }

--- a/Vonage.Test.Unit/NumbersTests.cs
+++ b/Vonage.Test.Unit/NumbersTests.cs
@@ -20,7 +20,7 @@ namespace Vonage.Test.Unit
         }
 
         [Fact]
-        public void TestBuyNumber()
+        public void BuyNumber()
         {
             const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
             const string expectedRequestContent = "country=GB&msisdn=447700900000&";
@@ -33,7 +33,7 @@ namespace Vonage.Test.Unit
         }
 
         [Fact]
-        public async Task TestBuyNumberAsync()
+        public async Task BuyNumberAsync()
         {
             const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
             const string expectedRequestContent = "country=GB&msisdn=447700900000&";
@@ -46,7 +46,7 @@ namespace Vonage.Test.Unit
         }
 
         [Fact]
-        public async Task TestBuyNumberAsyncWithCredentials()
+        public async Task BuyNumberAsyncWithCredentials()
         {
             const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
             const string expectedRequestContent = "country=GB&msisdn=447700900000&target_api_key=12345&";
@@ -60,7 +60,7 @@ namespace Vonage.Test.Unit
         }
 
         [Fact]
-        public void TestBuyNumberWithCredentials()
+        public void BuyNumberWithCredentials()
         {
             const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
             const string expectedRequestContent = "country=GB&msisdn=447700900000&target_api_key=12345&";
@@ -74,7 +74,7 @@ namespace Vonage.Test.Unit
         }
 
         [Fact]
-        public void TestCancelNumber()
+        public void CancelNumber()
         {
             const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
             const string expectedRequestContent = "country=GB&msisdn=447700900000&";
@@ -87,7 +87,7 @@ namespace Vonage.Test.Unit
         }
 
         [Fact]
-        public async Task TestCancelNumberAsync()
+        public async Task CancelNumberAsync()
         {
             const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
             const string expectedRequestContent = "country=GB&msisdn=447700900000&";
@@ -100,7 +100,7 @@ namespace Vonage.Test.Unit
         }
 
         [Fact]
-        public async Task TestCancelNumberAsyncWithCredentials()
+        public async Task CancelNumberAsyncWithCredentials()
         {
             const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
             const string expectedRequestContent = "country=GB&msisdn=447700900000&target_api_key=12345&";
@@ -114,7 +114,7 @@ namespace Vonage.Test.Unit
         }
 
         [Fact]
-        public void TestCancelNumberWithCredentials()
+        public void CancelNumberWithCredentials()
         {
             const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
             const string expectedRequestContent = "country=GB&msisdn=447700900000&target_api_key=12345&";
@@ -128,7 +128,7 @@ namespace Vonage.Test.Unit
         }
 
         [Fact]
-        public void TestFailedPurchase()
+        public void FailedPurchase()
         {
             const string expectedResponse =
                 @"{""error-code"": ""401"",""error-code-label"": ""authentication failed""}";
@@ -143,7 +143,7 @@ namespace Vonage.Test.Unit
         }
 
         [Fact]
-        public void TestSearchNumbers()
+        public void GetAvailableNumbers()
         {
             const string expectedResponse =
                 @"{""count"": 1234,""numbers"": [{""country"": ""GB"",""msisdn"": ""447700900000"",""type"": ""mobile-lvn"",""cost"": ""1.25"",""features"": [""VOICE"",""SMS""]}]}";
@@ -163,7 +163,7 @@ namespace Vonage.Test.Unit
         }
 
         [Fact]
-        public async Task TestSearchNumbersAsync()
+        public async Task GetAvailableNumbersAsync()
         {
             const string expectedResponse =
                 @"{""count"": 1234,""numbers"": [{""country"": ""GB"",""msisdn"": ""447700900000"",""type"": ""mobile-lvn"",""cost"": ""1.25"",""features"": [""VOICE"",""SMS""]}]}";
@@ -183,7 +183,7 @@ namespace Vonage.Test.Unit
         }
 
         [Fact]
-        public async Task TestSearchNumbersAsyncWithCredentials()
+        public async Task GetAvailableNumbersAsyncWithCredentials()
         {
             const string expectedResponse =
                 @"{""count"": 1234,""numbers"": [{""country"": ""GB"",""msisdn"": ""447700900000"",""type"": ""mobile-lvn"",""cost"": ""1.25"",""features"": [""VOICE"",""SMS""]}]}";
@@ -207,7 +207,7 @@ namespace Vonage.Test.Unit
         }
 
         [Fact]
-        public void TestSearchNumbersWithCredentials()
+        public void GetAvailableNumbersWithCredentials()
         {
             const string expectedResponse =
                 @"{""count"": 1234,""numbers"": [{""country"": ""GB"",""msisdn"": ""447700900000"",""type"": ""mobile-lvn"",""cost"": ""1.25"",""features"": [""VOICE"",""SMS""]}]}";
@@ -231,7 +231,95 @@ namespace Vonage.Test.Unit
         }
 
         [Fact]
-        public void TestUpdateNumber()
+        public void GetOwnedNumbers()
+        {
+            const string expectedResponse =
+                @"{""count"": 1234,""numbers"": [{""country"": ""GB"",""msisdn"": ""447700900000"",""type"": ""mobile-lvn"",""cost"": ""1.25"",""features"": [""VOICE"",""SMS""]}]}";
+            var expectedUri =
+                $"{this.RestUrl}/account/numbers?country=GB&api_key={this.ApiKey}&api_secret={this.ApiSecret}&";
+            var request = new NumberSearchRequest {Country = "GB"};
+            this.Setup(expectedUri, expectedResponse);
+            var response = this.client.NumbersClient.GetOwnedNumbers(request);
+            var number = response.Numbers[0];
+            Assert.Equal(1234, response.Count);
+            Assert.Equal("GB", number.Country);
+            Assert.Equal("447700900000", number.Msisdn);
+            Assert.Equal("mobile-lvn", number.Type);
+            Assert.Equal("1.25", number.Cost);
+            Assert.Equal("VOICE", number.Features[0]);
+            Assert.Equal("SMS", number.Features[1]);
+        }
+
+        [Fact]
+        public async Task GetOwnedNumbersAsync()
+        {
+            const string expectedResponse =
+                @"{""count"": 1234,""numbers"": [{""country"": ""GB"",""msisdn"": ""447700900000"",""type"": ""mobile-lvn"",""cost"": ""1.25"",""features"": [""VOICE"",""SMS""]}]}";
+            var expectedUri =
+                $"{this.RestUrl}/account/numbers?country=GB&api_key={this.ApiKey}&api_secret={this.ApiSecret}&";
+            var request = new NumberSearchRequest {Country = "GB"};
+            this.Setup(expectedUri, expectedResponse);
+            var response = await this.client.NumbersClient.GetOwnedNumbersAsync(request);
+            var number = response.Numbers[0];
+            Assert.Equal(1234, response.Count);
+            Assert.Equal("GB", number.Country);
+            Assert.Equal("447700900000", number.Msisdn);
+            Assert.Equal("mobile-lvn", number.Type);
+            Assert.Equal("1.25", number.Cost);
+            Assert.Equal("VOICE", number.Features[0]);
+            Assert.Equal("SMS", number.Features[1]);
+        }
+
+        [Fact]
+        public async Task GetOwnedNumbersAsyncWithCredentials()
+        {
+            const string expectedResponse =
+                @"{""count"": 1234,""numbers"": [{""country"": ""GB"",""msisdn"": ""447700900000"",""type"": ""mobile-lvn"",""cost"": ""1.25"",""features"": [""VOICE"",""SMS""]}]}";
+            var expectedUri =
+                $"{this.RestUrl}/account/numbers?country=GB&type=mobile-lvn&pattern=12345&search_pattern=1&features=SMS&size=10&index=1&api_key={this.ApiKey}&api_secret={this.ApiSecret}&";
+            var request = new NumberSearchRequest
+            {
+                Country = "GB", Type = "mobile-lvn", Pattern = "12345", SearchPattern = SearchPattern.Contains,
+                Features = "SMS", Size = 10, Index = 1,
+            };
+            this.Setup(expectedUri, expectedResponse);
+            var response = await this.client.NumbersClient.GetOwnedNumbersAsync(request, this.credentials);
+            var number = response.Numbers[0];
+            Assert.Equal(1234, response.Count);
+            Assert.Equal("GB", number.Country);
+            Assert.Equal("447700900000", number.Msisdn);
+            Assert.Equal("mobile-lvn", number.Type);
+            Assert.Equal("1.25", number.Cost);
+            Assert.Equal("VOICE", number.Features[0]);
+            Assert.Equal("SMS", number.Features[1]);
+        }
+
+        [Fact]
+        public void GetOwnedNumbersWithCredentials()
+        {
+            const string expectedResponse =
+                @"{""count"": 1234,""numbers"": [{""country"": ""GB"",""msisdn"": ""447700900000"",""type"": ""mobile-lvn"",""cost"": ""1.25"",""features"": [""VOICE"",""SMS""]}]}";
+            var expectedUri =
+                $"{this.RestUrl}/account/numbers?country=GB&type=mobile-lvn&pattern=12345&search_pattern=1&features=SMS&size=10&index=1&api_key={this.ApiKey}&api_secret={this.ApiSecret}&";
+            var request = new NumberSearchRequest
+            {
+                Country = "GB", Type = "mobile-lvn", Pattern = "12345", SearchPattern = SearchPattern.Contains,
+                Features = "SMS", Size = 10, Index = 1,
+            };
+            this.Setup(expectedUri, expectedResponse);
+            var response = this.client.NumbersClient.GetOwnedNumbers(request, this.credentials);
+            var number = response.Numbers[0];
+            Assert.Equal(1234, response.Count);
+            Assert.Equal("GB", number.Country);
+            Assert.Equal("447700900000", number.Msisdn);
+            Assert.Equal("mobile-lvn", number.Type);
+            Assert.Equal("1.25", number.Cost);
+            Assert.Equal("VOICE", number.Features[0]);
+            Assert.Equal("SMS", number.Features[1]);
+        }
+
+        [Fact]
+        public void UpdateNumber()
         {
             const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
             const string expectedRequestContent = "country=GB&msisdn=447700900000&";
@@ -244,7 +332,7 @@ namespace Vonage.Test.Unit
         }
 
         [Fact]
-        public async Task TestUpdateNumberAsync()
+        public async Task UpdateNumberAsync()
         {
             const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
             const string expectedRequestContent = "country=GB&msisdn=447700900000&";
@@ -257,7 +345,7 @@ namespace Vonage.Test.Unit
         }
 
         [Fact]
-        public async Task TestUpdateNumberAsyncWithCredentials()
+        public async Task UpdateNumberAsyncWithCredentials()
         {
             const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
             var expectedUri = $"{this.RestUrl}/number/update?api_key={this.ApiKey}&api_secret={this.ApiSecret}";
@@ -282,7 +370,7 @@ namespace Vonage.Test.Unit
         }
 
         [Fact]
-        public void TestUpdateNumberWithCredentials()
+        public void UpdateNumberWithCredentials()
         {
             const string expectedResponse = @"{""error-code"": ""200"",""error-code-label"": ""success""}";
             var expectedUri = $"{this.RestUrl}/number/update?api_key={this.ApiKey}&api_secret={this.ApiSecret}";

--- a/Vonage.Test.Unit/NumbersTests.cs
+++ b/Vonage.Test.Unit/NumbersTests.cs
@@ -131,22 +131,22 @@ namespace Vonage.Test.Unit
               ""error-code"": ""200"",
               ""error-code-label"": ""success""
             }";
-            var expectedUri = $"{RestUrl}/number/buy";
-            string expectdRequestContent = $"country=GB&msisdn=447700900000&api_key={ApiKey}&api_secret={ApiSecret}&";
+            var expectedUri = $"{RestUrl}/number/buy?api_key={ApiKey}&api_secret={ApiSecret}";
+            string expectedRequestContent;
             NumberTransactionRequest request;
 
             if (kitchenSink)
             {
-                expectdRequestContent = $"country=GB&msisdn=447700900000&target_api_key=12345&api_key={ApiKey}&api_secret={ApiSecret}&";
+                expectedRequestContent = $"country=GB&msisdn=447700900000&target_api_key=12345&";
                 request = new NumberTransactionRequest { Country = "GB", Msisdn = "447700900000", TargetApiKey="12345" };
             }
             else
             {
-                expectdRequestContent = $"country=GB&msisdn=447700900000&api_key={ApiKey}&api_secret={ApiSecret}&";
+                expectedRequestContent = $"country=GB&msisdn=447700900000&";
                 request = new NumberTransactionRequest { Country = "GB", Msisdn = "447700900000" };
             }
             
-            Setup(expectedUri, expectedResponse, expectdRequestContent);
+            Setup(expectedUri, expectedResponse, expectedRequestContent);
 
             var creds = Request.Credentials.FromApiKeyAndSecret(ApiKey, ApiSecret);
             var client = new VonageClient(creds);

--- a/Vonage/Numbers/INumbersClient.cs
+++ b/Vonage/Numbers/INumbersClient.cs
@@ -3,6 +3,9 @@ using Vonage.Request;
 
 namespace Vonage.Numbers
 {
+    /// <summary>
+    /// Represents a client for NumbersApi.
+    /// </summary>
     public interface INumbersClient
     {
         /// <summary>

--- a/Vonage/Numbers/NumbersClient.cs
+++ b/Vonage/Numbers/NumbersClient.cs
@@ -36,10 +36,13 @@ namespace Vonage.Numbers
 
         public async Task<NumberTransactionResponse> BuyANumberAsync(NumberTransactionRequest request, Credentials creds = null)
         {
+            var apiKey = (creds ?? Credentials).ApiKey;
+            var apiSecret = (creds ?? Credentials).ApiSecret;
             var response = await ApiRequest.DoPostRequestUrlContentFromObjectAsync<NumberTransactionResponse>(                
-                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/number/buy"),
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, $"/number/buy?api_key={apiKey}&api_secret={apiSecret}"),
                 request,                
-                creds ?? Credentials
+                creds ?? Credentials,
+                false
             );
             ValidateNumbersResponse(response);
             return response; 
@@ -47,10 +50,13 @@ namespace Vonage.Numbers
 
         public async Task<NumberTransactionResponse> CancelANumberAsync(NumberTransactionRequest request, Credentials creds = null)
         {
+            var apiKey = (creds ?? Credentials).ApiKey;
+            var apiSecret = (creds ?? Credentials).ApiSecret;
             var response = await ApiRequest.DoPostRequestUrlContentFromObjectAsync<NumberTransactionResponse>(                
-                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/number/cancel"),
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, $"/number/cancel?api_key={apiKey}&api_secret={apiSecret}"),
                 request,                
-                creds ?? Credentials
+                creds ?? Credentials,
+                false
             );
             ValidateNumbersResponse(response);
             return response;
@@ -58,10 +64,13 @@ namespace Vonage.Numbers
 
         public async Task<NumberTransactionResponse> UpdateANumberAsync(UpdateNumberRequest request, Credentials creds = null)
         {
+            var apiKey = (creds ?? Credentials).ApiKey;
+            var apiSecret = (creds ?? Credentials).ApiSecret;
             var response = await ApiRequest.DoPostRequestUrlContentFromObjectAsync<NumberTransactionResponse>(
-                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/number/update"),
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/number/update?api_key={apiKey}&api_secret={apiSecret}"),
                 request,
-                creds ?? Credentials
+                creds ?? Credentials,
+                false
             );
             ValidateNumbersResponse(response);
             return response;
@@ -112,10 +121,13 @@ namespace Vonage.Numbers
 
         public NumberTransactionResponse CancelANumber(NumberTransactionRequest request, Credentials creds = null)
         {
+            var apiKey = (creds ?? Credentials).ApiKey;
+            var apiSecret = (creds ?? Credentials).ApiSecret;
             var response = ApiRequest.DoPostRequestUrlContentFromObject<NumberTransactionResponse>(
-                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/number/cancel"),
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, $"/number/cancel?api_key={apiKey}&api_secret={apiSecret}"),
                 request,
-                creds ?? Credentials
+                creds ?? Credentials,
+                false
             );
             ValidateNumbersResponse(response);
             return response;
@@ -123,10 +135,13 @@ namespace Vonage.Numbers
 
         public NumberTransactionResponse UpdateANumber(UpdateNumberRequest request, Credentials creds = null)
         {
+            var apiKey = (creds ?? Credentials).ApiKey;
+            var apiSecret = (creds ?? Credentials).ApiSecret;
             var response = ApiRequest.DoPostRequestUrlContentFromObject<NumberTransactionResponse>(
-                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/number/update"),
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, $"/number/update?api_key={apiKey}&api_secret={apiSecret}"),
                 request,
-                creds ?? Credentials
+                creds ?? Credentials,
+                false
             );
             ValidateNumbersResponse(response);
             return response;

--- a/Vonage/Numbers/NumbersClient.cs
+++ b/Vonage/Numbers/NumbersClient.cs
@@ -1,172 +1,182 @@
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Vonage.Request;
 
 namespace Vonage.Numbers
 {
+    /// <inheritdoc />
     public class NumbersClient : INumbersClient
     {
-        public NumbersClient(Credentials creds = null)
-        {
-            Credentials = creds;
-        }
-        
+        private const string SuccessStatusCode = "200";
+
+        /// <summary>
+        ///     Gets or sets credentials to be used in further requests.
+        /// </summary>
         public Credentials Credentials { get; set; }
-        
-        public Task<NumbersSearchResponse> GetOwnedNumbersAsync(NumberSearchRequest request, Credentials creds = null)
-        {
-            return ApiRequest.DoGetRequestWithQueryParametersAsync<NumbersSearchResponse>(
-                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/account/numbers"), 
-                ApiRequest.AuthType.Query, 
-                request, 
-                creds ?? Credentials
-                );
-        }
 
-        public Task<NumbersSearchResponse> GetAvailableNumbersAsync(NumberSearchRequest request, Credentials creds = null)
-        {
-            return ApiRequest.DoGetRequestWithQueryParametersAsync<NumbersSearchResponse>(
-                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/number/search"), 
-                ApiRequest.AuthType.Query, 
-                request, 
-                creds ?? Credentials
-            );
-        }
+        /// <summary>
+        ///     Constructor for NumbersClients.
+        /// </summary>
+        /// <param name="credentials">Credentials to be used in further requests.</param>
+        public NumbersClient(Credentials credentials = null) => this.Credentials = credentials;
 
-        public async Task<NumberTransactionResponse> BuyANumberAsync(NumberTransactionRequest request, Credentials creds = null)
+        /// <inheritdoc />
+        public NumberTransactionResponse BuyANumber(NumberTransactionRequest request, Credentials creds = null)
         {
-            var apiKey = (creds ?? Credentials).ApiKey;
-            var apiSecret = (creds ?? Credentials).ApiSecret;
-            var response = await ApiRequest.DoPostRequestUrlContentFromObjectAsync<NumberTransactionResponse>(                
-                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, $"/number/buy?api_key={apiKey}&api_secret={apiSecret}"),
-                request,                
-                creds ?? Credentials,
-                false
-            );
-            ValidateNumbersResponse(response);
-            return response; 
-        }
-
-        public async Task<NumberTransactionResponse> CancelANumberAsync(NumberTransactionRequest request, Credentials creds = null)
-        {
-            var apiKey = (creds ?? Credentials).ApiKey;
-            var apiSecret = (creds ?? Credentials).ApiSecret;
-            var response = await ApiRequest.DoPostRequestUrlContentFromObjectAsync<NumberTransactionResponse>(                
-                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, $"/number/cancel?api_key={apiKey}&api_secret={apiSecret}"),
-                request,                
-                creds ?? Credentials,
+            var response = ApiRequest.DoPostRequestUrlContentFromObject<NumberTransactionResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest,
+                    $"/number/buy?{FormatQueryStringCredentials(creds ?? this.Credentials)}"),
+                request,
+                creds ?? this.Credentials,
                 false
             );
             ValidateNumbersResponse(response);
             return response;
         }
 
-        public async Task<NumberTransactionResponse> UpdateANumberAsync(UpdateNumberRequest request, Credentials creds = null)
+        /// <inheritdoc />
+        public async Task<NumberTransactionResponse> BuyANumberAsync(NumberTransactionRequest request,
+            Credentials creds = null)
         {
-            var apiKey = (creds ?? Credentials).ApiKey;
-            var apiSecret = (creds ?? Credentials).ApiSecret;
             var response = await ApiRequest.DoPostRequestUrlContentFromObjectAsync<NumberTransactionResponse>(
-                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, $"/number/update?api_key={apiKey}&api_secret={apiSecret}"),
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest,
+                    $"/number/buy?{FormatQueryStringCredentials(creds ?? this.Credentials)}"),
                 request,
-                creds ?? Credentials,
+                creds ?? this.Credentials,
                 false
             );
             ValidateNumbersResponse(response);
             return response;
         }
 
-        public static void ValidateNumbersResponse(NumberTransactionResponse response)
+        /// <inheritdoc />
+        public NumberTransactionResponse CancelANumber(NumberTransactionRequest request, Credentials creds = null)
         {
-            const string SUCCESS = "200";
-            if (response.ErrorCode != SUCCESS)
-            {
-                throw new VonageNumberResponseException($"Number Transaction failed with error code:{response.ErrorCode} and label {response.ErrorCodeLabel}"){ Response = response};
-            }
-        }
-
-        public NumbersSearchResponse GetOwnedNumbers(NumberSearchRequest request, Credentials creds = null)
-        {
-            return ApiRequest.DoGetRequestWithQueryParameters<NumbersSearchResponse>(
-                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/account/numbers"),
-                ApiRequest.AuthType.Query,
+            var response = ApiRequest.DoPostRequestUrlContentFromObject<NumberTransactionResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest,
+                    $"/number/cancel?{FormatQueryStringCredentials(creds ?? this.Credentials)}"),
                 request,
-                creds ?? Credentials
-                );
+                creds ?? this.Credentials,
+                false
+            );
+            ValidateNumbersResponse(response);
+            return response;
         }
 
-        public NumbersSearchResponse GetAvailableNumbers(NumberSearchRequest request, Credentials creds = null)
+        /// <inheritdoc />
+        public async Task<NumberTransactionResponse> CancelANumberAsync(NumberTransactionRequest request,
+            Credentials creds = null)
         {
-            return ApiRequest.DoGetRequestWithQueryParameters<NumbersSearchResponse>(
+            var response = await ApiRequest.DoPostRequestUrlContentFromObjectAsync<NumberTransactionResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest,
+                    $"/number/cancel?{FormatQueryStringCredentials(creds ?? this.Credentials)}"),
+                request,
+                creds ?? this.Credentials,
+                false
+            );
+            ValidateNumbersResponse(response);
+            return response;
+        }
+
+        /// <inheritdoc />
+        public NumbersSearchResponse GetAvailableNumbers(NumberSearchRequest request, Credentials creds = null) =>
+            ApiRequest.DoGetRequestWithQueryParameters<NumbersSearchResponse>(
                 ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/number/search"),
                 ApiRequest.AuthType.Query,
                 request,
-                creds ?? Credentials
+                creds ?? this.Credentials
             );
-        }
 
-        public NumberTransactionResponse BuyANumber(NumberTransactionRequest request, Credentials creds = null)
-        {
-            var apiKey = (creds ?? Credentials).ApiKey;
-            var apiSecret = (creds ?? Credentials).ApiSecret;
-            var response = ApiRequest.DoPostRequestUrlContentFromObject<NumberTransactionResponse>(
-                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, $"/number/buy?api_key={apiKey}&api_secret={apiSecret}"),
+        /// <inheritdoc />
+        public Task<NumbersSearchResponse> GetAvailableNumbersAsync(NumberSearchRequest request,
+            Credentials creds = null) =>
+            ApiRequest.DoGetRequestWithQueryParametersAsync<NumbersSearchResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/number/search"),
+                ApiRequest.AuthType.Query,
                 request,
-                creds ?? Credentials,
-                false
+                creds ?? this.Credentials
             );
-            ValidateNumbersResponse(response);
-            return response;
-        }
 
-        public NumberTransactionResponse CancelANumber(NumberTransactionRequest request, Credentials creds = null)
-        {
-            var apiKey = (creds ?? Credentials).ApiKey;
-            var apiSecret = (creds ?? Credentials).ApiSecret;
-            var response = ApiRequest.DoPostRequestUrlContentFromObject<NumberTransactionResponse>(
-                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, $"/number/cancel?api_key={apiKey}&api_secret={apiSecret}"),
+        /// <inheritdoc />
+        public NumbersSearchResponse GetOwnedNumbers(NumberSearchRequest request, Credentials creds = null) =>
+            ApiRequest.DoGetRequestWithQueryParameters<NumbersSearchResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/account/numbers"),
+                ApiRequest.AuthType.Query,
                 request,
-                creds ?? Credentials,
-                false
+                creds ?? this.Credentials
             );
-            ValidateNumbersResponse(response);
-            return response;
-        }
 
+        /// <inheritdoc />
+        public Task<NumbersSearchResponse>
+            GetOwnedNumbersAsync(NumberSearchRequest request, Credentials creds = null) =>
+            ApiRequest.DoGetRequestWithQueryParametersAsync<NumbersSearchResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/account/numbers"),
+                ApiRequest.AuthType.Query,
+                request,
+                creds ?? this.Credentials
+            );
+
+        /// <inheritdoc />
+        public NumberTransferResponse TransferANumber(NumberTransferRequest request, string apiKey,
+            Credentials creds = null) =>
+            ApiRequest.DoRequestWithJsonContent<NumberTransferResponse>(
+                "POST",
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, $"/accounts/{apiKey}/transfer-number"),
+                request,
+                ApiRequest.AuthType.Basic,
+                creds ?? this.Credentials
+            );
+
+        /// <inheritdoc />
+        public Task<NumberTransferResponse> TransferANumberAsync(NumberTransferRequest request, string apiKey,
+            Credentials creds = null) =>
+            ApiRequest.DoRequestWithJsonContentAsync<NumberTransferResponse>(
+                "POST",
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, $"/accounts/{apiKey}/transfer-number"),
+                request,
+                ApiRequest.AuthType.Basic,
+                creds ?? this.Credentials
+            );
+
+        /// <inheritdoc />
         public NumberTransactionResponse UpdateANumber(UpdateNumberRequest request, Credentials creds = null)
         {
-            var apiKey = (creds ?? Credentials).ApiKey;
-            var apiSecret = (creds ?? Credentials).ApiSecret;
             var response = ApiRequest.DoPostRequestUrlContentFromObject<NumberTransactionResponse>(
-                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, $"/number/update?api_key={apiKey}&api_secret={apiSecret}"),
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest,
+                    $"/number/update?{FormatQueryStringCredentials(creds ?? this.Credentials)}"),
                 request,
-                creds ?? Credentials,
+                creds ?? this.Credentials,
                 false
             );
             ValidateNumbersResponse(response);
             return response;
         }
-        
-        public NumberTransferResponse TransferANumber(NumberTransferRequest request, string apiKey, Credentials creds = null)
+
+        /// <inheritdoc />
+        public async Task<NumberTransactionResponse> UpdateANumberAsync(UpdateNumberRequest request,
+            Credentials creds = null)
         {
-            return ApiRequest.DoRequestWithJsonContent<NumberTransferResponse>(
-                "POST",
-                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, $"/accounts/{apiKey}/transfer-number"),
+            var response = await ApiRequest.DoPostRequestUrlContentFromObjectAsync<NumberTransactionResponse>(
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest,
+                    $"/number/update?{FormatQueryStringCredentials(creds ?? this.Credentials)}"),
                 request,
-                ApiRequest.AuthType.Basic,
-                creds: creds ?? Credentials
+                creds ?? this.Credentials,
+                false
             );
+            ValidateNumbersResponse(response);
+            return response;
         }
-        
-        public Task<NumberTransferResponse> TransferANumberAsync(NumberTransferRequest request, string apiKey, Credentials creds = null)
+
+        private static string FormatQueryStringCredentials(Credentials credentials) =>
+            $"api_key={credentials.ApiKey}&api_secret={credentials.ApiSecret}";
+
+        private static void ValidateNumbersResponse(NumberTransactionResponse response)
         {
-            return ApiRequest.DoRequestWithJsonContentAsync<NumberTransferResponse>(
-                "POST",
-                ApiRequest.GetBaseUri(ApiRequest.UriType.Api, $"/accounts/{apiKey}/transfer-number"),
-                request,
-                ApiRequest.AuthType.Basic,
-                creds: creds ?? Credentials
-            );
+            if (response.ErrorCode != SuccessStatusCode)
+            {
+                throw new VonageNumberResponseException(
+                        $"Number Transaction failed with error code:{response.ErrorCode} and label {response.ErrorCodeLabel}")
+                    {Response = response};
+            }
         }
     }
 }

--- a/Vonage/Numbers/NumbersClient.cs
+++ b/Vonage/Numbers/NumbersClient.cs
@@ -67,7 +67,7 @@ namespace Vonage.Numbers
             var apiKey = (creds ?? Credentials).ApiKey;
             var apiSecret = (creds ?? Credentials).ApiSecret;
             var response = await ApiRequest.DoPostRequestUrlContentFromObjectAsync<NumberTransactionResponse>(
-                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/number/update?api_key={apiKey}&api_secret={apiSecret}"),
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, $"/number/update?api_key={apiKey}&api_secret={apiSecret}"),
                 request,
                 creds ?? Credentials,
                 false

--- a/Vonage/Numbers/NumbersClient.cs
+++ b/Vonage/Numbers/NumbersClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Vonage.Request;
 
@@ -97,10 +98,13 @@ namespace Vonage.Numbers
 
         public NumberTransactionResponse BuyANumber(NumberTransactionRequest request, Credentials creds = null)
         {
+            var apiKey = (creds ?? Credentials).ApiKey;
+            var apiSecret = (creds ?? Credentials).ApiSecret;
             var response = ApiRequest.DoPostRequestUrlContentFromObject<NumberTransactionResponse>(
-                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, "/number/buy"),
+                ApiRequest.GetBaseUri(ApiRequest.UriType.Rest, $"/number/buy?api_key={apiKey}&api_secret={apiSecret}"),
                 request,
-                creds ?? Credentials
+                creds ?? Credentials,
+                false
             );
             ValidateNumbersResponse(response);
             return response;

--- a/Vonage/Request/ApiRequest.cs
+++ b/Vonage/Request/ApiRequest.cs
@@ -185,13 +185,14 @@ namespace Vonage.Request
         /// <param name="uri"></param>
         /// <param name="parameters"></param>
         /// <param name="creds"></param>
+        /// <param name="withCredentials">Indicates whether credentials should be included in Query string.</param>
         /// <returns></returns>
         /// <exception cref="VonageHttpRequestException">thrown if an error is encountered when talking to the API</exception>
         public static async Task<T> DoPostRequestUrlContentFromObjectAsync<T>(Uri uri, object parameters,
-            Credentials creds = null)
+            Credentials creds = null, bool withCredentials = true)
         {
             var apiParams = GetParameters(parameters);
-            return await DoPostRequestWithUrlContentAsync<T>(uri, apiParams, creds);
+            return await DoPostRequestWithUrlContentAsync<T>(uri, apiParams, creds, withCredentials);
         }
         
         private static T DoPostRequestWithUrlContent<T>(Uri uri, Dictionary<string, string> parameters,
@@ -202,9 +203,9 @@ namespace Vonage.Request
         }
         
         private static async Task<T> DoPostRequestWithUrlContentAsync<T>(Uri uri, Dictionary<string, string> parameters,
-            Credentials creds = null)
+            Credentials creds = null, bool withCredentials = true)
         {
-            var response = await DoRequestWithUrlContentAsync("POST", uri, parameters, creds: creds);
+            var response = await DoRequestWithUrlContentAsync("POST", uri, parameters, creds: creds, withCredentials: withCredentials);
             return JsonConvert.DeserializeObject<T>(response.JsonResponse);
         }
 
@@ -321,7 +322,7 @@ namespace Vonage.Request
         }
         
         private static async Task<VonageResponse> DoRequestWithUrlContentAsync(string method, Uri uri,
-            Dictionary<string, string> parameters, AuthType authType = AuthType.Query, Credentials creds = null)
+            Dictionary<string, string> parameters, AuthType authType = AuthType.Query, Credentials creds = null, bool withCredentials = true)
         {
             var logger = LogProvider.GetLogger(LoggerCategory);
             var sb = new StringBuilder();
@@ -329,7 +330,7 @@ namespace Vonage.Request
             // if parameters is null, assume that key and secret have been taken care of            
             if (null != parameters)
             {
-                sb = GetQueryStringBuilderFor(parameters, authType, creds);
+                sb = GetQueryStringBuilderFor(parameters, authType, creds, withCredentials);
             }
 
             var req = new HttpRequestMessage


### PR DESCRIPTION
Move ApiKey/ApiSecret in the query string for NumbersAPI instead of the body.
The weird part is that the body is a computed query string that always includes credentials. This method is used by several endpoints and is painful to change. The method is not tested individually (only through E2E tests) with a high complexity index.
I implemented an easy workaround: an additional optional parameter to exclude credentials from the query string. This is clearly a short-term solution, given my long-term goal is to decommission this unmaintainable ApiRequest anyway.

Other tasks included in this PR:
- Refactor Number Tests to make them easier to understand and maintain (especially remove the branching in tests)
- Add missing Xml Documentations on NumbersClient
- Automatic cleaning/formatting/ordering

Here's the method to compute the query string:
https://github.com/Vonage/vonage-dotnet-sdk/blob/3c54086064050d68418cc9f81a262fdf757b27ce/Vonage/Request/ApiRequest.cs#L493-L559