### PR TITLE
fix: exclude '{' and '}' from non-empty strings in PBT

### DIFF
--- a/Vonage.Common.Test/Extensions/FsCheckExtensions.cs
+++ b/Vonage.Common.Test/Extensions/FsCheckExtensions.cs
@@ -35,7 +35,8 @@ namespace Vonage.Common.Test.Extensions
         ///     Retrieves a string generator that produces only non-null/non-empty string.
         /// </summary>
         /// <returns>An Arbitrary of strings.</returns>
-        public static Arbitrary<string> GetNonEmptyStrings() =>
-            GetAny<string>().MapFilter(_ => _, value => !string.IsNullOrWhiteSpace(value));
+        public static Arbitrary<string> GetNonDeserializableStrings() =>
+            GetAny<string>().MapFilter(_ => _,
+                value => !string.IsNullOrWhiteSpace(value) && value.Contains("{") && value.Contains("}"));
     }
 }

--- a/Vonage.Common.Test/Extensions/FsCheckExtensions.cs
+++ b/Vonage.Common.Test/Extensions/FsCheckExtensions.cs
@@ -9,13 +9,6 @@ namespace Vonage.Common.Test.Extensions
     public static class FsCheckExtensions
     {
         /// <summary>
-        ///     Retrieves a generator that produces any value.
-        /// </summary>
-        /// <typeparam name="T">Type of the value.</typeparam>
-        /// <returns>An Arbitrary.</returns>
-        public static Arbitrary<T> GetAny<T>() => Arb.From<T>();
-
-        /// <summary>
         ///     Retrieves a generator that produces error responses with invalid status codes.
         /// </summary>
         /// <returns>An Arbitrary of ErrorResponse.</returns>
@@ -37,6 +30,13 @@ namespace Vonage.Common.Test.Extensions
         /// <returns>An Arbitrary of strings.</returns>
         public static Arbitrary<string> GetNonDeserializableStrings() =>
             GetAny<string>().MapFilter(_ => _,
-                value => !string.IsNullOrWhiteSpace(value) && value.Contains("{") && value.Contains("}"));
+                value => !string.IsNullOrWhiteSpace(value) && value.Contains('{') && value.Contains('}'));
+
+        /// <summary>
+        ///     Retrieves a generator that produces any value.
+        /// </summary>
+        /// <typeparam name="T">Type of the value.</typeparam>
+        /// <returns>An Arbitrary.</returns>
+        internal static Arbitrary<T> GetAny<T>() => Arb.From<T>();
     }
 }

--- a/Vonage.Common.Test/UseCaseHelper.cs
+++ b/Vonage.Common.Test/UseCaseHelper.cs
@@ -135,7 +135,7 @@ namespace Vonage.Common.Test
             Func<VonageHttpClientConfiguration, Task<Result<TResponse>>> operation) =>
             Prop.ForAll(
                 FsCheckExtensions.GetInvalidStatusCodes(),
-                FsCheckExtensions.GetNonEmptyStrings(),
+                FsCheckExtensions.GetNonDeserializableStrings(),
                 (statusCode, jsonError) =>
                 {
                     var messageHandler = FakeHttpRequestHandler.Build(statusCode)


### PR DESCRIPTION
Fix for issue https://github.com/Vonage/vonage-dotnet-sdk/issues/396