### PR TITLE
Decorates StartOnEnter with DefaultValue(true) 

### DIFF
--- a/Vonage/Voice/Nccos/ConversationAction.cs
+++ b/Vonage/Voice/Nccos/ConversationAction.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System.ComponentModel;
 using Vonage.Serialization;
 
 namespace Vonage.Voice.Nccos;
@@ -28,6 +29,7 @@ public class ConversationAction : NccoAction
     /// </summary>
     [JsonProperty("startOnEnter")]
     [JsonConverter(typeof(StringBoolConverter))]
+    [DefaultValue(true)]
     public bool StartOnEnter { get; set; }
 
     /// <summary>


### PR DESCRIPTION
…to serialize a value of false into the response, otherwise it's not possible to differentiate between moderator and attendees.

Solves #463 
