### PR TITLE
fix: conversation StartOnEnter

### DIFF
--- a/Vonage.Test.Unit/Data/NccoTests/TestConversation-request.json
+++ b/Vonage.Test.Unit/Data/NccoTests/TestConversation-request.json
@@ -5,6 +5,7 @@
     "musicOnHoldUrl": [
       "https://example.com/music.mp3"
     ],
+    "startOnEnter": "false",
     "canSpeak": [
       "6a4d6af0-55a6-4667-be90-8614e4c8e83c"
     ],

--- a/Vonage/Voice/Nccos/ConversationAction.cs
+++ b/Vonage/Voice/Nccos/ConversationAction.cs
@@ -3,82 +3,89 @@ using Vonage.Serialization;
 
 namespace Vonage.Voice.Nccos;
 
+/// <summary>
+///     Represents a NCCO Conversation.
+/// </summary>
 public class ConversationAction : NccoAction
 {
+    /// <summary>
+    /// Returns the Conversation ActionType.
+    /// </summary>
+    [JsonProperty("action", Order = 0)]
     public override ActionType Action => ActionType.Conversation;
 
     /// <summary>
-    /// The name of the Conversation room. Names are namespaced to the application level.
+    ///     A list of leg UUIDs that this participant can hear.
+    ///     If not provided, the participant can hear everyone.
+    ///     If an empty list is provided, the participant will not hear any other participants
     /// </summary>
-    [JsonProperty("name")]
-    public string Name { get; set; }
+    [JsonProperty("canHear", Order = 7)]
+    public string[] CanHear { get; set; }
 
     /// <summary>
-    /// A URL to the mp3 file to stream to participants until the conversation starts. 
-    /// By default the conversation starts when the first person calls the virtual number 
-    /// associated with your Voice app. To stream this mp3 before the moderator joins the 
-    /// conversation, set startOnEnter to false for all users other than the moderator.
+    ///     A list of leg UUIDs that this participant can be heard by.
+    ///     If not provided, the participant can be heard by everyone.
+    ///     If an empty list is provided, the participant will not be heard by anyone
     /// </summary>
-    [JsonProperty("musicOnHoldUrl")]
-    public string[] MusicOnHoldUrl { get; set; }
+    [JsonProperty("canSpeak", Order = 6)]
+    public string[] CanSpeak { get; set; }
 
     /// <summary>
-    /// The default value of true ensures that the conversation starts when this caller 
-    /// joins conversation name. Set to false for attendees in a moderated conversation.
+    ///     Specifies whether a moderated conversation ends when the moderator hangs up.
+    ///     This is set to false by default, which means that the conversation only ends
+    ///     when the last remaining participant hangs up, regardless of whether the moderator
+    ///     is still on the call. Set endOnExit to true to terminate the conversation when the
+    ///     moderator hangs up.
     /// </summary>
-    [JsonProperty("startOnEnter")]
-    [JsonConverter(typeof(StringBoolConverter))]
-    public bool StartOnEnter { get; set; }
-
-    /// <summary>
-    /// Specifies whether a moderated conversation ends when the moderator hangs up. 
-    /// This is set to false by default, which means that the conversation only ends 
-    /// when the last remaining participant hangs up, regardless of whether the moderator 
-    /// is still on the call. Set endOnExit to true to terminate the conversation when the 
-    /// moderator hangs up.
-    /// </summary>
-    [JsonProperty("endOnExit")]
+    [JsonProperty("endOnExit", Order = 4)]
     [JsonConverter(typeof(StringBoolConverter))]
     public bool EndOnExit { get; set; }
 
     /// <summary>
-    /// Set to true to record this conversation. For standard conversations, 
-    /// recordings start when one or more attendees connects to the conversation. 
-    /// For moderated conversations, recordings start when the moderator joins. 
-    /// That is, when an NCCO is executed for the named conversation where startOnEnter is set 
-    /// to true. When the recording is terminated, the URL you download the recording 
-    /// from is sent to the event URL. By default audio is recorded in MP3 format.
-    /// See the recording guide for more details
-    /// </summary>
-    [JsonProperty("record")]
-    [JsonConverter(typeof(StringBoolConverter))]
-    public bool Record { get; set; }
-       
-    /// <summary>
-    /// Url to receive webhooks at for the conversation
-    /// </summary>
-    [JsonProperty("eventUrl")]
-    public string[] EventUrl { get; set; }
-
-    /// <summary>
-    /// Method to use on the webhooks for the conversation
+    ///     Method to use on the webhooks for the conversation
     /// </summary>
     [JsonProperty("eventMethod")]
     public string EventMethod { get; set; }
 
     /// <summary>
-    /// A list of leg UUIDs that this participant can be heard by. 
-    /// If not provided, the participant can be heard by everyone. 
-    /// If an empty list is provided, the participant will not be heard by anyone
+    ///     Url to receive webhooks at for the conversation
     /// </summary>
-    [JsonProperty("canSpeak")]
-    public string[] CanSpeak { get; set; }
+    [JsonProperty("eventUrl")]
+    public string[] EventUrl { get; set; }
 
     /// <summary>
-    /// A list of leg UUIDs that this participant can hear. 
-    /// If not provided, the participant can hear everyone. 
-    /// If an empty list is provided, the participant will not hear any other participants
+    ///     A URL to the mp3 file to stream to participants until the conversation starts.
+    ///     By default the conversation starts when the first person calls the virtual number
+    ///     associated with your Voice app. To stream this mp3 before the moderator joins the
+    ///     conversation, set startOnEnter to false for all users other than the moderator.
     /// </summary>
-    [JsonProperty("canHear")]
-    public string[] CanHear { get; set; }
+    [JsonProperty("musicOnHoldUrl", Order = 2)]
+    public string[] MusicOnHoldUrl { get; set; }
+
+    /// <summary>
+    ///     The name of the Conversation room. Names are namespaced to the application level.
+    /// </summary>
+    [JsonProperty("name", Order = 1)]
+    public string Name { get; set; }
+
+    /// <summary>
+    ///     Set to true to record this conversation. For standard conversations,
+    ///     recordings start when one or more attendees connects to the conversation.
+    ///     For moderated conversations, recordings start when the moderator joins.
+    ///     That is, when an NCCO is executed for the named conversation where startOnEnter is set
+    ///     to true. When the recording is terminated, the URL you download the recording
+    ///     from is sent to the event URL. By default audio is recorded in MP3 format.
+    ///     See the recording guide for more details
+    /// </summary>
+    [JsonProperty("record", Order = 5)]
+    [JsonConverter(typeof(StringBoolConverter))]
+    public bool Record { get; set; }
+
+    /// <summary>
+    ///     The default value of true ensures that the conversation starts when this caller
+    ///     joins conversation name. Set to false for attendees in a moderated conversation.
+    /// </summary>
+    [JsonProperty("startOnEnter", DefaultValueHandling = DefaultValueHandling.Include, Order = 3)]
+    [JsonConverter(typeof(StringBoolConverter))]
+    public bool StartOnEnter { get; set; }
 }


### PR DESCRIPTION
The default value is supposed to be `true`, but the default serializer options ignore default values. As the default for bool is `false`, the value is never provided.
The main problem is even more significant: `true` is never the default value on the object itself...

Changing the default serialization options would generate too many side effects. 
I set the following on the `StartOnEnter`property instead:
```csharp
DefaultValueHandling = DefaultValueHandling.Include
```

https://github.com/Vonage/vonage-dotnet-sdk/issues/463