### PR TITLE
ci: increase java version to 17

### DIFF
--- a/.github/workflows/net-build.yml
+++ b/.github/workflows/net-build.yml
@@ -10,10 +10,11 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.11
+          distribution: 'microsoft'
+          java-version: '17'
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:


### PR DESCRIPTION
Increase java version to 17, as the current version is outdated.
This is required for the SonarSource analysis

https://github.com/Vonage/vonage-dotnet-sdk/issues/480