### PR TITLE
refactor: remove InternalsVisibleTo property

### DIFF
--- a/Vonage.Server.Test/TestHelpers/E2EHelper.cs
+++ b/Vonage.Server.Test/TestHelpers/E2EHelper.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
 using Vonage.Request;
 using Vonage.Server.Video;
 using WireMock.Server;
@@ -10,13 +12,11 @@ namespace Vonage.Server.Test.TestHelpers
         private E2EHelper(string appSettingsKey, Credentials credentials)
         {
             this.Server = WireMockServer.Start();
-            var configuration = new Configuration
-            {
-                Settings =
+            var configuration = Configuration.FromConfiguration(new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
                 {
-                    [$"appSettings:{appSettingsKey}"] = this.Server.Url,
-                },
-            };
+                    {$"appSettings:{appSettingsKey}", this.Server.Url},
+                }).Build());
             this.VonageClient = new VideoClient(credentials, configuration);
         }
 

--- a/Vonage/Vonage.csproj
+++ b/Vonage/Vonage.csproj
@@ -88,9 +88,6 @@
             <PackagePath>lib\netstandard2.0</PackagePath>
         </_PackageFiles>
     </ItemGroup>
-    <ItemGroup>
-        <InternalsVisibleTo Include="Vonage.Server.Test"/>
-    </ItemGroup>
     <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
         <Exec Command="node ../.scripts/init.js"/>
     </Target>


### PR DESCRIPTION
Use factory method to create Configuration instead.

This was causing an issue when building a Signed version