### PR TITLE
fix: [breaking] make StartTime nullable on Answered webhook

### DIFF
--- a/Vonage.Test/Data/Webhooks/ShouldDeserializedAnswered_GivenStartTimeIsNull.json
+++ b/Vonage.Test/Data/Webhooks/ShouldDeserializedAnswered_GivenStartTimeIsNull.json
@@ -1,0 +1,15 @@
+﻿{
+  "start_time": null,
+  "headers": {
+    "[redacted]": "[redacted]"
+  },
+  "rate": null,
+  "from": "[redacted]",
+  "to": "[redacted]",
+  "uuid": "c8061992c89a65e3790bfa0aaca6f069",
+  "conversation_uuid": "CON-5a0cdebb-0f35-45a4-9b38-a99f9d12d6d7",
+  "status": "answered",
+  "direction": "inbound",
+  "network": null,
+  "timestamp": "2024-01-25T12:16:32.319Z"
+}

--- a/Vonage.Test/Vonage.Test.csproj
+++ b/Vonage.Test/Vonage.Test.csproj
@@ -1092,6 +1092,9 @@
         <None Update="Conversations\GetUserConversations\Data\ShouldDeserialize200-response.json">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Update="Data\Webhooks\ShouldDeserializedAnswered_GivenStartTimeIsNull.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
     </ItemGroup>
     <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
         <Exec Command="node ../.scripts/init.js"/>

--- a/Vonage.Test/WebhookStructsTest.cs
+++ b/Vonage.Test/WebhookStructsTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.IO;
+using FluentAssertions;
 using Newtonsoft.Json;
 using Vonage.Voice.AnswerWebhooks;
 using Vonage.Voice.EventWebhooks;
@@ -389,8 +390,9 @@ public class WebhookStructsTest
     public void ShouldDeserializedAnswered_GivenStartTimeIsNull()
     {
         var deserializedEvent =
-            EventBase.ParseEvent(
+            (Answered) EventBase.ParseEvent(
                 File.ReadAllText("Data/Webhooks/ShouldDeserializedAnswered_GivenStartTimeIsNull.json"));
+        deserializedEvent.StartTime.Should().BeNull();
     }
 
     public class Foo

--- a/Vonage.Test/WebhookStructsTest.cs
+++ b/Vonage.Test/WebhookStructsTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.IO;
 using Newtonsoft.Json;
 using Vonage.Voice.AnswerWebhooks;
 using Vonage.Voice.EventWebhooks;
@@ -382,6 +383,14 @@ public class WebhookStructsTest
             CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal |
                                           DateTimeStyles.AdjustToUniversal), transferWebhook.TimeStamp);
         Assert.Equal("aaaaaaaa-bbbb-cccc-dddd-0123456789ab", transferWebhook.Uuid);
+    }
+
+    [Fact]
+    public void ShouldDeserializedAnswered_GivenStartTimeIsNull()
+    {
+        var deserializedEvent =
+            EventBase.ParseEvent(
+                File.ReadAllText("Data/Webhooks/ShouldDeserializedAnswered_GivenStartTimeIsNull.json"));
     }
 
     public class Foo

--- a/Vonage/Voice/EventWebhooks/Answered.cs
+++ b/Vonage/Voice/EventWebhooks/Answered.cs
@@ -1,5 +1,5 @@
-﻿using Newtonsoft.Json;
-using System;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace Vonage.Voice.EventWebhooks;
 
@@ -9,14 +9,14 @@ public class Answered : CallStatusEvent
     /// call start time
     /// </summary>
     [JsonProperty("start_time")]
-    public DateTime StartTime { get; set; }
+    public DateTime? StartTime { get; set; }
 
     /// <summary>
     /// cost rate for the call
     /// </summary>
     [JsonProperty("rate")]
     public string Rate { get; set; }
-        
+
     /// <summary>
     /// Network the call came from
     /// </summary>


### PR DESCRIPTION
Fix for issue https://github.com/Vonage/vonage-dotnet-sdk/issues/567
The start time value can be null, but the related property isn't