### PR TITLE
Fix edge case importing RSA key

### DIFF
--- a/Vonage/PemParse.cs
+++ b/Vonage/PemParse.cs
@@ -45,8 +45,8 @@ THE SOFTWARE.
 //  Creates dummy unsigned certificate linked to private keypair and
 //  optionally exports to pkcs #12
 //
-// See also: 
-//  http://www.openssl.org/docs/crypto/pem.html#PEM_ENCRYPTION_FORMAT 
+// See also:
+//  http://www.openssl.org/docs/crypto/pem.html#PEM_ENCRYPTION_FORMAT
 //**************************************************************************************
 
 using System;
@@ -177,6 +177,12 @@ internal class PemParse
                     RSA = new RSACng();
                 }
 #endif
+                if (D.Length < MODULUS.Length)
+                {
+                    var newD = new byte[MODULUS.Length];
+                    Array.Copy(D, 0, newD, MODULUS.Length - D.Length, D.Length);
+                    D = newD;
+                }
                 var RSAparams = new RSAParameters
                 {
                     Modulus = MODULUS,
@@ -220,7 +226,7 @@ internal class PemParse
         catch (FormatException)
         {
             //if can't b64 decode, it must be an encrypted private key
-            //Console.WriteLine("Not an unencrypted OpenSSL PEM private key");  
+            //Console.WriteLine("Not an unencrypted OpenSSL PEM private key");
         }
 
         throw new NotSupportedException("Encrypted key not supported");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes edge case Exception importing private key when `D` is shorter in length than `MODULUS` by 8 bits or more.

If `D` is shorter, it is copied to the end of a new array with the same length as `MODULUS`. Naive, but this is a rare edge case.

## Motivation and Context

This fixes issue #357 that I just ran into using an older Vonage application private key.

## How Has This Been Tested?

Ran unit tests with old and new keys and published to our production server (which uses multiple private keys).
